### PR TITLE
Refactor the app to focus on GitHub testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bugcatcher-web",
-  "version": "1.0.132",
+  "version": "1.0.134",
   "repository": {
     "type": "git",
     "url": "https://github.com/faster-than-light/bugcatcher-web.git"
@@ -17,7 +17,7 @@
     "file-selector": "0.1.12",
     "js-sha256": "0.9.0",
     "moment": "2.24.0",
-    "node-bugcatcher": "1.0.31",
+    "node-bugcatcher": "1.0.32",
     "node-fetch": "2.6.0",
     "octokit-create-pull-request": "1.4.2",
     "query-string": "6.11.1",

--- a/src/App.js
+++ b/src/App.js
@@ -3,17 +3,19 @@ import { BrowserRouter, Route, Switch } from 'react-router-dom'
 
 // components
 import Account from './views/Account'
-// import BulkGithub from './views/BulkGithub'
 import Code from './views/Code'
 import CookiesAlert from './components/CookiesAlert'
 import CQC from './views/CQC'
+import Dashboard from './views/Dashboard'
 import FAQ from './views/FAQ/FAQ'
 import GitHub from './views/GitHub'
 import GitHubOAuth from './views/GitHubOAuth'
 import Home from './views/Home'
 // import Pricing from './views/Pricing'
 import Project from './views/Project'
+import Projects from './views/Projects'
 import Publish from './views/Publish'
+import Repositories from './views/GitHub/Repositories'
 import Results from './views/Results'
 import SetSid from './views/SetSid'
 import Tests from './views/Tests'
@@ -102,17 +104,20 @@ class App extends Component {
             <Route path="/account" component={() => <Account {...props} />} exact />
             {/* <Route path="/bulkgithub" component={() => <BulkGithub {...props} />} exact /> */}
             <Route path="/cqc" component={() => <CQC {...props} />} exact />
+            <Route path="/code/:id" component={Code} exact />
+            <Route path="/dashboard" component={() => <Dashboard {...props} />} exact />
             <Route path="/faq" component={() => <FAQ {...props} />} exact />
             <Route path="/github/gh_auth" component={() => <GitHub {...props} />} exact />
             <Route path="/github" component={() => <GitHub {...props} />} exact />
             <Route path="/github/oauth" component={() => <GitHubOAuth {...props} />} exact />
             {/* <Route path="/pricing" component={() => <Pricing {...props} />} exact /> */}
-            <Route path="/projects" component={() => <Project {...props} />} exact />
+            <Route path="/projects" component={() => <Projects {...props} />} exact />
             <Route path="/tests" component={() => <Tests {...props} />} exact />
             <Route path="/thankyou" component={() => <ThankYou {...props} />} exact />
             <Route path="/tour" component={() => <Tour {...props} />} exact />
-            <Route path="/project/:id" component={Code} exact />
+            <Route path="/project/:id" component={Project} exact />
             <Route path="/publish/:id" component={Publish} exact />
+            <Route path="/github/repos" component={() => <Repositories {...props} />} exact />
             <Route path="/results/:id" component={Results} exact />
             <Route path="/sid/:sid" component={SetSid} exact />
           </Switch>

--- a/src/assets/css/App.css
+++ b/src/assets/css/App.css
@@ -63,12 +63,17 @@ code, pre {
 }
 
 /* containers */
+.ftl-section {
+  max-width: 1236px;
+  margin: auto;
+  text-align: left;
+}
 .theme {
   min-height: 100vh;
   background-color: var(--color-background);
 }
 .contents {
-  padding: 90px 24px 0 24px;
+  padding: 0 24px;
   max-width: 900px;
   margin: auto;
 }

--- a/src/assets/css/Project.css
+++ b/src/assets/css/Project.css
@@ -1,0 +1,126 @@
+#project {
+  /* margin-top: 111px; */
+  padding-bottom: 90px;
+  text-align: center;
+}
+.project-container {
+  background: var(--color-background-offset);
+  color: var(--color-dark-text);
+  box-shadow: 1px 1px 4.5px #bbb;
+  /* border-radius: 9px; */
+  margin: 18px auto;
+  padding: 18px;
+}
+#project .lead i {
+  color: brown;
+}
+#project .btn {
+  font-size: 15px;
+  line-height: 1.8rem;
+}
+#project .btn.small {
+  padding: 3px 9px;
+  font-size: 90%;
+}
+
+#project .or {
+  font-size: large;
+  color: var(--color-dark-text);
+  padding-bottom: 15px;
+}
+
+#project .overview-segment .segment {
+  min-height: 234px;
+}
+
+#project .issues-table td:nth-child(2) {
+  text-align: center;
+}
+#project .issues-table th {
+  font-size: 90%;
+  border: none;
+  color: rgb(112, 112, 112);
+}
+#project .issues-table .red {
+  color: rgb(133, 14, 14);
+  background: rgb(270, 234, 234);
+  font-weight: bold;
+  font-size: 111%;
+}
+#project .issues-table .orange {
+  color: rgb(168, 100, 22);
+  background: rgb(255, 238, 205);
+  font-weight: bold;
+  font-size: 111%;
+}
+#project .issues-table .yellow {
+  color: rgb(133, 125, 14);
+  background: rgb(255, 255, 218);
+  font-weight: bold;
+  font-size: 111%;
+}
+
+@media (min-width: 768px) {
+  .overview-segment {
+    width: 48%;
+    min-height: auto;
+    float: left;
+    margin: 0 0.5% !important;
+  }
+  #project .github-button {
+    float: right;
+  }
+}
+@media (max-width: 768px) {
+  #project .github-button {
+    margin-left: 9px;
+  }
+}
+
+
+/**
+ * Upload status blocks
+ */
+.upload-status {
+  margin-bottom: 21px;
+  font-size: 100%;
+}
+.upload-status .icon {
+  font-size: 123%;
+  margin-right: 12px;
+}
+.upload-status div.error,
+.upload-status div.success,
+.upload-status div.info {
+  padding: 6px;
+  margin: 9px 0;
+  opacity: 0.81;
+  border-radius: 9px;
+}
+.upload-status div.error {
+  background: var(--color-file-status-bg-error);
+  color: var(--color-file-status-text-error);
+}
+.upload-status div.success {
+  background: var(--color-file-status-bg-success);
+  color: var(--color-file-status-text-success);
+}
+.upload-status div.info {
+  background: var(--color-file-status-bg-info);
+  color: var(--color-file-status-text-info);
+}
+
+
+/** Tabs */
+.ftl-tabs .ui.secondary.pointing.menu {
+  margin: 12px 18px 0 18px;
+  border-bottom: 0;
+}
+.ftl-tabs .ui.secondary.pointing.menu .active.item {
+  color: var(--color-primary);
+  border-color: var(--color-secondary);
+}
+.ftl-tabs .ui.segment {
+  border-radius: 0 !important;
+  margin-top: 2px !important;
+}

--- a/src/assets/css/UploadFiles.css
+++ b/src/assets/css/UploadFiles.css
@@ -14,7 +14,7 @@
   color: var(--color-dark-text);
   box-shadow: 1px 1px 4.5px #bbb;
   border-radius: 9px;
-  margin: 12px auto;
+  /* margin: 12px auto; */
   padding: 12px;
 }
 #upload .lead i {

--- a/src/assets/css/components/Menu.css
+++ b/src/assets/css/components/Menu.css
@@ -1,6 +1,6 @@
-.menu {
-  position: fixed;
-  top: 0;
+.ftl-menu {
+  /* position: fixed; */
+  /* top: 0; */
   z-index: 999;
   color: var(--color-dark-text);
   background-color: var(--color-background-offset);
@@ -22,16 +22,16 @@
   top: 0;
   width: 100%;
 }
-.menu a {
+.ftl-menu a {
   color: var(--color-dark-text);
   cursor: pointer;
   text-decoration: none;
 }
-.menu .link {
+.ftl-menu .link {
   color: var(--color-dark-text);
 }
-.menu a:hover,
-.menu .link:hover {
+.ftl-menu a:hover,
+.ftl-menu .link:hover {
   color: #00acc9;
 }
 .menu-menu > .link:first-child {
@@ -42,36 +42,36 @@
   color: var(--color-dark-text);
 }
 
-.menu .avatar {
+.ftl-menu .avatar {
   width: 36px;
   height: 36px;
   margin-right: 9px;
   vertical-align: middle;
 }
 
-.menu .home-link {
+.ftl-menu .home-link {
   float: left;
   font-size: 1.23rem;
 }
-.menu .home-link img {
+.ftl-menu .home-link img {
   width: 33px;
   height: 33px;
   vertical-align: middle;
   margin-right: 12px;
 }
 
-.menu .logo-text {
+.ftl-menu .logo-text {
   font-family: StarTrek;
   letter-spacing: 0.0321em;
   font-size: 150%;
 }
 
-.menu .nav-links {
+.ftl-menu .nav-links {
   padding-left: 21px;
   float: left;
 }
-.menu .nav-links a,
-.menu .nav-links .btn {
+.ftl-menu .nav-links a,
+.ftl-menu .nav-links .btn {
   display: inline-block;
   padding: 9px 21px;
   cursor: pointer;
@@ -117,11 +117,11 @@
   }
 }
 @media (max-width: 768px) {
-  .menu .nav-links {
+  .ftl-menu .nav-links {
     padding-left: 12px;
   }
-  .menu .nav-links a,
-  .menu .nav-links .btn {
+  .ftl-menu .nav-links a,
+  .ftl-menu .nav-links .btn {
     padding: 4.5px 12px;
   }
 }

--- a/src/components/FileList.js
+++ b/src/components/FileList.js
@@ -1,0 +1,233 @@
+import React, { Component } from 'react'
+import { Checkbox, Icon, Table } from 'semantic-ui-react'
+
+// components
+import FileRow from './FileRow'
+import StlButton from './StlButton'
+
+// context
+import { UserContext } from '../contexts/UserContext'
+
+// helpers
+import api from '../helpers/api'
+import { appendS } from '../helpers/strings'
+import { noLeadingSlash } from '../helpers/strings'
+
+// images and styles
+import '../assets/css/components/Code.css'
+
+export default class FileList extends Component {
+  state = {
+    open: false,
+    selectedRows: []
+  }
+
+  selectedRows = () => {
+    const inputs = document.getElementsByTagName("input")
+    let rows = []
+    for(let i = 0; i < inputs.length; i++) {
+        if (inputs[i].type === "checkbox")
+          if (inputs[i].checked) {
+            if (inputs[i].value.length) rows.push({
+              name: inputs[i].value,
+              sha256: inputs[i].sha256,
+            })}
+    }
+    return rows
+  }
+
+  selectAll = (e,f) => {
+    const inputs = document.getElementsByTagName("input")
+    for(let i = 0; i < inputs.length; i++) {
+        if(inputs[i].type === "checkbox") {
+            inputs[i].checked = f.checked
+        }
+    }
+    // const selectAllIsChecked = !this.selectAllToggle.state.checked
+    const selectAllIsChecked = !this.state.selectAllIsChecked
+    this.setState({
+      selectAllIsChecked,
+      selectedRows: this.selectedRows()
+    })
+  }
+
+  async deleteCode() {
+    const { selectedRows = [] } = this.state
+    const {
+      removeFileToUpload,
+      restoreDirName,
+      showLoader,
+      setState,
+      state,
+      updateCode
+    } = this.props
+    const {
+      binaryFilesToUpload,
+      codeOnServer,
+      filesToUpload,
+      step,
+      uploadButtonClassname,
+    } = state
+    setState({ numFilesToDelete: selectedRows.length })
+    if (!selectedRows || !selectedRows.length) {
+      this.optionSelector.selectedIndex = 0
+      return
+    }
+    const msg = `Are you sure you want to delete ${selectedRows.length ? selectedRows.length : ''} file${appendS(selectedRows.length)}`
+    var conf = window.confirm(msg)
+    if (conf) {
+      showLoader( true )
+      let numFilesToDelete = selectedRows.length
+      let numFilesDeleted = 0
+      let numDeleteFailures = 0
+      let deletedRows = []
+      const checkForEnd = () => {
+        if (numFilesDeleted + numDeleteFailures === numFilesToDelete) {
+          showLoader( false )
+          const deletedFileNames = deletedRows.map(d =>d.name)
+          const restoredDirDeletedFileNames = deletedRows.map(d =>restoreDirName(d.name))
+          const newBinaryFilesToUpload = binaryFilesToUpload.filter(b => !restoredDirDeletedFileNames
+            .includes(noLeadingSlash(b.path)))
+          const newCodeOnServer = codeOnServer.filter(c => !deletedFileNames
+            .includes(c.name))
+          setState({
+            binaryFilesToUpload: newBinaryFilesToUpload,
+            codeOnServer: newCodeOnServer,
+            filesToUpload: filesToUpload.filter(f => !restoredDirDeletedFileNames
+              .includes(noLeadingSlash(f.path))),
+            step: newCodeOnServer.length ? step : 1,
+            uploadButtonClassname: newCodeOnServer.length ? uploadButtonClassname : 'hide',
+          })
+        }
+      }
+      for (let i = 0; i < selectedRows.length; i++) {
+        const row = selectedRows[i]
+        const match = binaryFilesToUpload.find(
+          c => noLeadingSlash(c.path) === restoreDirName(row.name)
+        )
+        if (!match) {
+          api.deleteCode(
+            encodeURIComponent(this.props.state.projectName) + '/' + encodeURIComponent(row.name)
+          )
+          .then(res => {
+            if (res) {
+              numFilesDeleted++
+              updateCode(row)
+              deletedRows.push(row)
+              checkForEnd()
+            }
+          })
+          .catch(err => {
+            console.error(err)
+            numDeleteFailures++
+            updateCode(row, 'failed')
+            checkForEnd()
+          })
+        }
+        else {
+          // remove from binaryFilesToUpload
+          numFilesDeleted++
+          await removeFileToUpload(row)
+          deletedRows.push(row)
+          checkForEnd()
+        }
+      }
+    }
+  }
+
+  render() {
+    const { selectedRows } = this.state
+    const {
+      state,
+      toggleDropzone,
+    } = this.props
+    const {
+      codeOnServer = [],
+      showDropzone,
+    } = state
+    codeOnServer.sort((a, b) => !a.name || !b.name ? null : a.name.localeCompare(b.name))
+
+    const Items = () => codeOnServer.length ?
+      codeOnServer.map((r, i) => <FileRow key={r.name + i}
+        selectedRows={this.selectedRows}
+        checked={selectedRows.map(row => row.name).includes(r.name)}
+        saveRows={rows => { this.setState({ selectedRows: rows }) }}
+        data={r} />) : <Table.Row key={0}><Table.Cell>There are no files associated with this project or branch. You can initiate a test on this branch by clicking the button below.
+          
+          <p><br /><StlButton semantic className="small" onClick={() => {this.props.runTests(true)}}>Initiate a Test</StlButton></p>
+          </Table.Cell></Table.Row>
+
+    const CodeTable = (props) => (
+      <Table celled striped className={'data-table'}>
+        <Table.Body>
+          {props.children}
+        </Table.Body>
+      </Table>
+    )
+
+    const Actions = () => {
+      return <div className={'actions'}>
+        <a title={showDropzone ? 'Hide Dropzone' : 'Add Files'}
+          className="secondary-color"
+          style={{
+            display: codeOnServer && codeOnServer.length ? 'inline-block' : 'none',
+            float: 'right',
+            fontSize: '100%',
+            cursor: 'pointer',
+            marginRight: 9,
+            // marginTop: 30,
+          }}
+          onClick={toggleDropzone}>
+          {showDropzone ? 'hide dropzone' : 'add files'}
+          <Icon name={showDropzone ? 'minus circle' : 'add circle'}
+            style={{ marginLeft: 9, verticalAlign: 'baseline' }} />
+        </a>
+        <Checkbox //ref={r => this.selectAllToggle = r}
+          onChange={this.selectAll}
+          checked={this.state.selectAllIsChecked}
+          style={{
+            marginLeft: 12,
+            display: codeOnServer.length ? 'inline-block' : 'none'
+          }}
+          label="select / deselect all"
+          title="select/deselect all" />
+        <span style={{fontSize: '120%', marginLeft: 12}}>&#8592;</span>
+        <StlButton semantic default
+          className={`small ${!selectedRows.length ? 'disabled' : 'primary'}`}
+          disabled={!selectedRows.length}
+          style={{
+            marginLeft: 12
+          }}
+          onClick={this.deleteCode.bind(this)}>
+          {
+            !selectedRows.length ?
+            `Delete Files` :
+            `Delete ${selectedRows.length} selected File${appendS(selectedRows.length)}`
+          }
+        </StlButton>
+      </div>
+    }
+
+    const ActionsBottom = () => codeOnServer.length > 5 ? <Actions /> : null
+
+    return (
+      <section className="code">
+        <UserContext.Consumer>
+          {(context) => {
+            const { user } = context ? context.state : {}
+            if (user) return <div style={{
+              // display: this.props.state.showCodeList ? 'block' : 'none'
+            }}>
+              {/* <Actions /> */}
+              <CodeTable>
+                <Items />
+              </CodeTable>
+              {/* <ActionsBottom /> */}
+            </div>
+            else return null
+          }}
+        </UserContext.Consumer>
+      </section>
+    )
+  }
+}

--- a/src/components/FileRow.js
+++ b/src/components/FileRow.js
@@ -1,0 +1,62 @@
+import React, { Component } from 'react'
+import { Checkbox, Header, Icon, Modal, Label, Table } from 'semantic-ui-react'
+
+export default class FileRow extends Component {
+  state = { modalOpen: false }
+
+  handleOpen = () => this.setState({ modalOpen: true })
+
+  handleClose = () => this.setState({ modalOpen: false })
+
+  render() {
+    const {
+      name,
+      sha256,
+      status,
+    } = this.props.data
+
+    const StatusIcon = () => {
+      switch (status) {
+        case 'failed': return <Icon name="warning sign" color="red" />
+        case 'sync': return <Icon name="sync" />
+        case 'upload': return <Icon name="upload" color="green" />
+        default: return <Icon name="file code outline" />
+      }
+    }
+
+    const Details = () => (
+      <span
+        // onClick={this.handleOpen}
+      >
+        <StatusIcon style={{ fontSize: '1.23rem' }} /> {name}
+        {/* &nbsp;<Icon name="close" style={{marginTop: 6, color: '#ccc'}} /> */}
+      </span>
+    )
+
+    const boxClicked = (e, t) => {
+      let rows = this.props.selectedRows()
+      if (t.checked) rows = rows.concat({
+        name: t.value,
+        sha256: t.sha256
+      })
+      else rows = rows.filter(r => r.name !== t.value)
+      this.props.saveRows( rows )
+    }
+
+    const TableRow = () => (
+      <Table.Row>
+        <Table.Cell style={{ padding: '3px 9px' }}>
+          {/* <Checkbox value={name}
+            style={{ marginRight: 12 }}
+            sha256={sha256}
+            onChange={boxClicked}
+            checked={this.props.checked} /> */}
+          <Details />
+        </Table.Cell>
+      </Table.Row>
+    )
+
+    return <TableRow />
+
+  }
+}

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -53,7 +53,7 @@ export default class Menu extends Component {
 
     return (
       <nav id="ftl_navbar"
-        className={`navbar navbar-expand-lg navbar-light bg-light menu${showMobileMenu ? ' mobile-menu' : ''}`}
+        className={`navbar navbar-expand-lg navbar-light bg-light ftl-menu${showMobileMenu ? ' mobile-menu' : ''}`}
         {...this.props}>
         <Link className="navbar-brand home-link" to={`/`}>
           <img src={logoOnly} alt="Faster Than Light" /> <span className="logo-text">Faster Than Light</span>
@@ -90,13 +90,13 @@ export default class Menu extends Component {
                   onClick={() =>{
                     // window.mixpanel.track('Log Out', { version })
                     setUser(null)
-                    this.logoutButton.signOut()
+                    // this.logoutButton.signOut()
                     setTimeout(
                       () => window.location.reload(),
                       999
                     )
                   }}>log out</button>
-                  <GoogleLogout
+                  {/* <GoogleLogout
                     buttonText="log out"
                     className={'link'}
                     id="google_login"
@@ -105,7 +105,7 @@ export default class Menu extends Component {
                       visibility: 'hidden',
                       position: 'absolute',
                     }}
-                  />
+                  /> */}
                 </React.Fragment>
                 else return <React.Fragment>
                   <Welcome />

--- a/src/components/ProjectList.js
+++ b/src/components/ProjectList.js
@@ -10,7 +10,7 @@ import { UserContext } from '../contexts/UserContext'
 
 // helpers
 import api from '../helpers/api'
-import { appendS } from '../helpers/strings'
+import { appendS, uriEncodeProjectName, uriDecodeProjectName } from '../helpers/strings'
 import { getCookie, setCookie } from '../helpers/cookies'
 import LocalStorage from '../helpers/LocalStorage'
 
@@ -67,7 +67,7 @@ export default class ProjectList extends Component {
         numProjectsToDelete--
       }
       this.state.selectedRows.forEach(p => {
-        api.deleteProject(p)
+        api.deleteProject(uriEncodeProjectName(uriDecodeProjectName(p)))
         .then(res => {
           if (res) {
             numProjectsToDelete--

--- a/src/components/ProjectRow.js
+++ b/src/components/ProjectRow.js
@@ -2,6 +2,9 @@ import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import { Checkbox, Icon, Table } from 'semantic-ui-react'
 
+// helpers
+import { uriDecodeProjectName } from '../helpers/strings'
+
 export default class ProjectRow extends Component {
   state = { modalOpen: false }
 
@@ -35,7 +38,7 @@ export default class ProjectRow extends Component {
           <Link to={`/project/${name}`}
             style={{ color: icon === 'code' ? 'black' : 'red' }}>
             <Icon name={icon === 'code' ? 'folder open' : 'warning sign'}
-              style={{ fontSize: '1.23rem' }} /> {name}
+              style={{ fontSize: '1.23rem' }} /> {uriDecodeProjectName(name)}
           </Link>
         </Table.Cell>
       </Table.Row>

--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -40,6 +40,22 @@ export class UserProvider extends Component {
     }
   }
 
+  setUser = user => {
+    user = extendUser(user)
+    LocalStorage.User.setUser(user)
+    this.setState({ user })
+    if (user && typeof user === 'object') {
+      setCookie('session', user.sid)
+      api.setSid(user.sid)
+    }
+    else {
+      setCookie('session', '')
+      setCookie('tokenId', '')
+      setCookie(github.tokenCookieName, '')
+      api.setSid(null)
+    }
+  }
+
   actions = {
     fetchUser: async (clearStorage) => {
       this.setState({ userDataLoaded: false })
@@ -90,21 +106,14 @@ export class UserProvider extends Component {
         return extendUser(user)
       }
     },
-    setUser: user => {
-      user = extendUser(user)
-      LocalStorage.User.setUser(user)
-      this.setState({ user })
-      if (user && typeof user === 'object') {
-        setCookie('session', user.sid)
-        api.setSid(user.sid)
-      }
-      else {
-        setCookie('session', '')
-        setCookie('tokenId', '')
-        setCookie(github.tokenCookieName, '')
-        api.setSid(null)
-      }
-    },
+    setUser: this.setUser,
+    logOut: () => {
+      this.setUser(null)
+      setTimeout(
+        () => window.location.reload(),
+        999
+      )
+    }
   }
 
   render() {

--- a/src/helpers/LocalStorage.js
+++ b/src/helpers/LocalStorage.js
@@ -51,10 +51,12 @@ class ProjectTestResults {
     return project ? sids[project] || [] : sids
   }
   static setIds(project, sids) {
-    sids = Array.isArray(sids) ? sids.filter( (item, i, ar) => ar.indexOf(item) === i ) : []
+    sids = Array.isArray(sids) ? sids.filter( (item, i, ar) => ar.indexOf(item) === i ) : null
     if (window.localStorage) {
       let projectStlIds = this.getIds()
-      projectStlIds[project] = sids
+      console.log({projectStlIds})
+      if (!sids) delete projectStlIds[project]
+      else projectStlIds[project] = sids
       window.localStorage.setItem('projectStlIds', JSON.stringify(projectStlIds))
     }
   }

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -1,4 +1,5 @@
 import { subscriberEntitlementName } from '../config'
+import { severities } from './strings'
 
 export const fetchEntitlement = (user, entitlement) => (
   user && user.entitlements && user.entitlements.find(
@@ -10,3 +11,113 @@ export const fetchEntitlement = (user, entitlement) => (
 export const isSubscriber = user => Boolean(
   fetchEntitlement(user, subscriberEntitlementName)
 )
+
+export const buildResultsMatrix = results => {
+  let resultsMatrix = {
+    low: 0,
+    medium: 0,
+    high: 0,
+  }
+  if (results && results.test_run_result) results.test_run_result.forEach(hit => {
+    const test_suite_test = hit['test_suite_test']
+    const ftl_severity = test_suite_test['ftl_severity']
+    resultsMatrix[ftl_severity]++
+  })
+  return resultsMatrix
+}
+
+export const groupedResultsJson = (testRunResult, project) => {
+  /**
+   * @dev Arrange results into Grouped Rows
+   */
+
+  const sortRowsByFileLine = (a, b) =>
+    String(a.code.name + a.start_line).localeCompare(
+      String(b.code.name + b.start_line)
+    )
+
+  let certified = true
+
+  const reducedResults = testRunResult.reduce((acc, item) => {
+    const { test_suite_test: test } = item
+    const { ftl_severity: severity } = test
+    if (severity === 'high') certified = false
+    acc[severity] = acc[severity] || []
+    acc[severity].push(item)
+    return acc
+  }, {})
+  severities.forEach(s => {
+    if (!reducedResults[s]) reducedResults[s] = []
+  })
+
+  /** @dev Sort results */
+  const titleReducer = (acc, item) => {
+    const { test_suite_test: test } = item
+    const { ftl_short_description: title } = test
+    acc[title] = acc[title] || []
+    acc[title].push(item)
+    return acc
+  }
+
+  reducedResults.high = new Map(Object.entries(reducedResults.high.reduce(titleReducer, {}))) || []
+  reducedResults.medium = new Map(Object.entries(reducedResults.medium.reduce(titleReducer, {}))) || []
+  reducedResults.low = new Map(Object.entries(reducedResults.low.reduce(titleReducer, {}))) || []
+  reducedResults.info = new Map(Object.entries(reducedResults.info.reduce(titleReducer, {}))) || []
+
+  const descriptionReducer = (acc, item) => {
+    const { test_suite_test: test } = item
+    const { ftl_long_description: description } = test
+    acc[description] = acc[description] || []
+    acc[description].push(item)
+    return acc
+  }
+  let groupedResults = {}
+  Object.entries(reducedResults).forEach(r => {
+    const key = r[0]
+    const value = r[1]
+    let m = new Map()
+    Array.from(value).forEach(v => {
+      m.set(v[0], v[1].reduce(descriptionReducer, {}))
+    })
+    groupedResults[key] = m
+  })
+
+  const groupedResultsArray = [].concat(
+    groupedResults.high,
+    groupedResults.medium,
+    groupedResults.low,
+    groupedResults.info
+  )
+
+  let rows = []
+  groupedResultsArray.forEach((titlesGroup, i) => {
+    const titles = Array.from(titlesGroup)
+    if (titles && titles.length)
+      titles.forEach(t => {
+        const hits = Object.entries(t[1]).map(d => {
+          return {
+            project,
+            testId: d[1][0]['test_suite_test']['ftl_test_id'],
+            testResultId: d[1][0]['test_run_result_id'],
+            annotation: d[1][0]['project_annotation'],
+            severity: severities[i],
+            title: t[0],
+            description: d[0],
+            location: d[1].sort(sortRowsByFileLine).map(f => ([
+              `${f.code.name} (lines ${f.start_line} - ${f.end_line})`,
+              f.commentary
+            ])),
+            resources: d[1].map(h =>
+              typeof h.test_suite_test.more_information_uris === 'object' ?
+              JSON.parse(
+                h.test_suite_test.more_information_uris.replace(/'/g, '"')
+              ) : []
+            )[0],
+          }
+        })
+        rows.push(hits)
+      })
+  })
+  return [rows.flat(), certified]
+}
+

--- a/src/helpers/githubApi.js
+++ b/src/helpers/githubApi.js
@@ -40,7 +40,7 @@ async function getAccessToken(code) {
  */
 async function getRepos(sort, direction) {
   const { data: repos } = await get(`/user/repos?sort=${sort}&direction=${direction}`)
-  return repos.map(r => r.full_name)
+  return repos.map(r => r)
 }
 
 async function getBranch(owner, repo, branch) {

--- a/src/helpers/strings.js
+++ b/src/helpers/strings.js
@@ -1,3 +1,22 @@
+const cleanProjectName = (projectName) => {
+  if (!projectName) return ''
+  // projectName = projectName.replace(/\//g, '%2F')
+  const delims = ["<", ">", "#", "%", '"']
+  const reserved = [";", "?", ":", "@", "&", "=", "+", "$", ","]
+  const unwise = ["{", "}", "|", "\\", "^", "[", "]", "`"]
+  const forbidden = [
+    ...delims,
+    ...reserved,
+    ...unwise,
+  ]
+  let cleanString = ''
+  projectName.split('').map(a => a).forEach(a => {
+    cleanString += !forbidden.includes(a) ? a : ''
+  })
+  cleanString = cleanString.replace(/\//g, '%2F')
+  return cleanString
+}
+
 module.exports = {
   appendS: (count) => count === 1 ? '' : 's',
   base64ToBlob: (data) => {
@@ -35,22 +54,22 @@ module.exports = {
       default: case "error": return 'red'
     }
   },
-  cleanProjectName: (projectName) => {
-    if (!projectName) return ''
-    projectName = projectName.replace(/\//g, '_')
-    const delims = ["<", ">", "#", "%", '"']
-    const reserved = [";", "/", "?", ":", "@", "&", "=", "+", "$", ","]
-    const unwise = ["{", "}", "|", "\\", "^", "[", "]", "`"]
-    const forbidden = [
-      ...delims,
-      ...reserved,
-      ...unwise,
-    ]
-    let cleanString = ''
-    projectName.split('').map(a => a).forEach(a => {
-      cleanString += !forbidden.includes(a) ? a : ''
-    })
-    return cleanString
+  cleanProjectName,
+  destructureProjectName: (projectName) => {
+    // @todo: Destructuring is not working here
+    // const [ project, branch ] = projectName.split('/tree/')
+    if (!projectName) return
+    try {
+      projectName = projectName.split('/tree/')
+      const project = projectName[0]
+      const branch = projectName[1]
+      const owner = project.split('/')[0]
+      const repo = project.split('/')[1]
+      return [ owner, repo, branch ]
+    }
+    catch(e) { return projectName.split('/') }
   },
+  uriEncodeProjectName: (projectName) => encodeURIComponent(cleanProjectName(projectName)),//.replace(/%2F/g, '%252F'),
+  uriDecodeProjectName: (projectName) => projectName.replace(/%2F/g, '/'),
   noLeadingSlash: (s) => (s && s.substring(0, 1) === '/') ? s.substring(1) : s,
 }

--- a/src/views/CQC/index.js
+++ b/src/views/CQC/index.js
@@ -21,6 +21,7 @@ import Menu from '../../components/Menu'
 
 // helpers
 import api from '../../helpers/api'
+import { buildResultsMatrix } from '../../helpers/data'
 import { appUrl, github } from '../../config'
 import { getCookie, setCookie } from '../../helpers/cookies'
 import githubApi from '../../helpers/githubApi'
@@ -656,17 +657,7 @@ class CQC extends Component {
         const results = await this.fetchTestResults(queueItem)//.catch(() => null)
         if (results) {
           const { data } = results
-          let resultsMatrix = {
-            low: 0,
-            medium: 0,
-            high: 0,
-          }
-          data.test_run_result.forEach(hit => {
-            const test_suite_test = hit['test_suite_test']
-            const ftl_severity = test_suite_test['ftl_severity']
-            resultsMatrix[ftl_severity]++
-          })
-          queueItem.resultsMatrix = resultsMatrix
+          queueItem.resultsMatrix = buildResultsMatrix(data)
         }
 
         queueItem.status = constStatus.COMPLETE

--- a/src/views/Dashboard.js
+++ b/src/views/Dashboard.js
@@ -158,7 +158,7 @@ SEVERITY_THRESHOLD=${severity}`
 
     const newProject = () => {
       let projectName = prompt('What is the name of your project?')
-      projectName = cleanProjectName(projectName)
+      // projectName = cleanProjectName(projectName)
       if (projectName.length) this.setState({
         addNewProject: encodeURIComponent(
           projectName.trim().replace(/\s\s+/g, ' ')
@@ -194,13 +194,13 @@ SEVERITY_THRESHOLD=${severity}`
     }
     
     if (!this.props.user) return <Redirect to={'/'} />
-    else if (addNewProject) return <Redirect to={`/project/${addNewProject}`} />
+    else if (addNewProject) return <Redirect to={`/code/${addNewProject}`} />
     else return <div id="dashboard">
       <Menu />
       <div style={{
         maxWidth: 720,
         margin: 'auto',
-        paddingTop: 111,
+        paddingTop: 30,
       }}>
         {/* <Link to="/cqc"><h1>CQC</h1></Link> */}
 
@@ -221,7 +221,7 @@ SEVERITY_THRESHOLD=${severity}`
                 onClick={newProject}>
                 Upload &amp; Test A Project
               </FtlButton>,
-              <Link to={'/github'}>
+              <Link to={'/github/repos'}>
                 <FtlButton className="github-button">
                   Fetch and Test a&nbsp;&nbsp;
                   <img src={githubLogo} alt="GitHub Logo" />

--- a/src/views/GitHub/Repositories/index.js
+++ b/src/views/GitHub/Repositories/index.js
@@ -1,0 +1,527 @@
+import React, { Component } from 'react'
+import { Link, Redirect } from 'react-router-dom'
+import queryString from 'query-string'
+import { Icon, Input, Table } from 'semantic-ui-react'
+import { Loader } from 'semantic-ui-react'
+
+// components
+import FtlLoader from '../../../components/Loader'
+import Menu from '../../../components/Menu'
+import StlButton from '../../../components/StlButton'
+
+// helpers
+import api from '../../../helpers/api'
+import { appUrl, github } from '../../../config'
+import { getCookie, setCookie } from '../../../helpers/cookies'
+import { uriDecodeProjectName } from '../../../helpers/strings'
+import githubApi from '../../../helpers/githubApi'
+
+// images & styles
+import bugcatcherShield from '../../../assets/images/bugcatcher-shield-square.png'
+import githubLogo from '../../../assets/images/github-logo.png'
+import '../../../assets/css/Github.css'
+
+/** Constants */
+const initialState = {
+  code: null,
+  currentRepo: null,
+  branches: null,
+  branchName: null,
+  projects: null,
+  redirect: null,
+  repos: null,
+  sortReposBy: 'full_name',
+  sortReposDirection: 'asc',
+  token: null,
+  tree: null,
+  user: null,
+  working: false,
+}
+const { automateCookieName, tokenCookieName } = github
+
+export default class Repositories extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = initialState
+
+    this.toggleAutomateOption = this.toggleAutomateOption.bind(this)
+    this.ApiFunctions = this.ApiFunctions.bind(this)
+    this.RepoList = this.RepoList.bind(this)
+    this.LoadingRepos = this.LoadingRepos.bind(this)
+    this._getTree = githubApi.getTree.bind(this)
+  }
+
+  async componentWillMount() {
+    const { data } = await api.getProject().catch(() => null)
+    const projects = data['response']
+    this.setState({ projects, working: true })
+    const code = queryString.parse(document.location.search)['code']
+    let token = getCookie(tokenCookieName)
+    token = token.length ? token : null
+
+    let { user } = this.state
+    if (!token && code) {
+      token = await this.fetchToken()
+      if (window.history.pushState) {
+        const newurl = `${window.location.protocol}//${window.location.host}/github/repos`
+        window.history.pushState({path: newurl}, '', newurl)
+      }
+    }
+    if (token) {
+      await githubApi.setToken(token)
+      user = await this.fetchUser(true)
+    }
+    if (!token && !user && !code) this.props.setUser(null)
+    else this.setState({
+      addingProjects: projects && !projects.length,
+      code: !user && code ? code : null,
+      token,
+      user,
+      working: false,
+    })
+
+  }
+
+  componentDidMount() {
+    document.addEventListener("keydown", this.fetchRepoKeydownEvent)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("keydown", this.fetchRepoKeydownEvent)
+  }
+
+  fetchRepoKeydownEvent = event => {
+    if (
+      event.target["id"] === 'custom_repo' && (
+        event.code === 'Enter' || event.keyCode === 13
+      )
+    ) this.fetchCustomRepo()
+  }
+  
+  async toggleAutomateOption(event) {
+    const automate = event.target.checked
+    await setCookie(automateCookieName, automate)
+  }
+  
+  resetState = () => {
+    setCookie(tokenCookieName, '')
+    this.setState(initialState)
+  }
+
+  runApiFunctions = async () => {
+    const { code, repos, token, user } = this.state
+    if (code && !token) await this.fetchToken()
+    if (!user) await this.fetchUser(true)
+    if (!repos) await this.fetchRepos()
+  }
+  
+  ApiFunctions = () => {
+    this.runApiFunctions()
+    return null
+  }
+  
+  fetchToken = async alertError => {
+    let token
+    try {
+      const getAccessToken = await githubApi.getAccessToken(this.state.code)
+      token = getAccessToken['token']
+    } catch(e) { console.error(e) }
+    if (!token) {
+      if (alertError) alert('There was a problem fetching a token. Please try again.')
+      this.resetState()
+    }
+    else {
+      setCookie(tokenCookieName, token)
+      this.setState({ token })
+    }
+    return token
+  }
+
+  fetchUser = async alertError => {
+    let user = await githubApi.getAuthenticated() 
+      .catch(e => { console.error(e);return null })
+    if (!user) {
+      if (alertError) alert("There was a problem fetching your Profile. Please start over and try again.")
+      this.resetState()
+    }
+    else this.setState({ user })
+    return user
+  }
+
+  fetchRepos = async alertError => {
+    let repos
+    try {
+      repos = await githubApi.getRepos(
+        this.state.sortReposBy,
+        this.state.sortReposDirection
+      )
+    }
+    catch(e) { console.error(e) }
+    if (!repos && alertError) alert("There was a problem fetching your Repository List. Please start over and try again.")
+    else this.setState({ repos, contents: null })
+    return repos
+  }
+
+  FetchAccessToken = (props) => <StlButton primary semantic disabled={Boolean(this.state.token)}
+    style={props.style}
+    onClick={async () => {
+      this.setState({ working: true })
+      await this.fetchToken(true)
+      this.setState({ working: false }) 
+    }}>Fetch Access Token &laquo;</StlButton>
+
+  FetchUserProfile = (props) => <StlButton primary semantic
+    disabled={Boolean(!this.state.token || this.state.user)}
+    style={props.style}
+    onClick={ async () => {
+      this.setState({ working: true })
+      await this.fetchUser(true)
+      this.setState({ working: false })
+    }}>Fetch User Profile &raquo;</StlButton>
+
+  RepoList = () => {
+    let { addingProjects, branches, branchName, projects, repos } = this.state
+
+    if (projects && repos && !branches) {
+      const ProjectsRows = projects.map((project, k) => {
+        const wasTested = repos.find(r => {
+          return project.startsWith(r.full_name.replace(/\//g, '%2F') + '%2Ftree%2F')
+        })
+        if (wasTested) return null
+        const clickFn = () => { this.setState({ redirect: `/project/${project}` }) }
+        return <Table.Row key={k} style={{ display: !wasTested || addingProjects ? 'block' : 'none' }}>
+          <Table.Cell style={{ borderLeft: !wasTested ? '6px solid #2185d0' : 'normal', width: '100%', display: 'block' }}>
+            
+              <StlButton onClick={clickFn} semantic primary
+                className="small" style={{
+                  float: 'right',
+                  display: !wasTested ? 'none' : 'inline-block'
+                }}><Icon name="add" />&nbsp;Add</StlButton>
+              <Icon name={!wasTested ? 'code' : 'code branch'} style={{ color: !wasTested ? '#2185d0' : 'inherit' }} />&nbsp;
+              <a onClick={clickFn}>{project}</a>
+          </Table.Cell>
+        </Table.Row>
+      })
+
+      const RepoRows = repos.map((repo, k) => {
+        const wasTested = projects.find(p => p.startsWith(repo.full_name.replace(/\//g, '%2F') + '%2Ftree%2F'))
+        const clickFn = !wasTested ? () => { this.getBranches(repo) } : () => { this.setState({ redirect: `/project/${encodeURIComponent(wasTested)}`}) }
+        return <Table.Row key={k} style={{ display: (wasTested || addingProjects) ? 'block' : 'none' }}>
+          <Table.Cell style={{
+              borderLeft: wasTested ? '6px solid #2185d0' : 'normal',
+              width: '100%',
+              display: 'block',
+              color: '#666',
+            }}>
+            
+              <StlButton onClick={clickFn} semantic
+                className="small" style={{
+                  float: 'right',
+                  display: wasTested ? 'none' : 'inline-block'
+                }}><Icon name="add" />&nbsp;Add</StlButton>
+              <Icon name={wasTested ? 'code branch' : 'code branch'} style={{ color: wasTested ? '#2185d0' : 'inherit' }} />&nbsp;
+              
+              {
+                wasTested ? <a onClick={clickFn}>{repo.full_name}</a> : repo.full_name
+              }
+              
+          </Table.Cell>
+        </Table.Row>
+      })
+
+      return <div className="repo-list">
+        {/* {specifyRepo}
+        <hr /> */}
+        {/* <div style={{
+          width: 'auto',
+          float: 'right',
+          // paddingTop: 15,
+        }}>
+          Sort:&nbsp;
+          <select onChange={this.sortOptionChange} defaultValue="full_name">
+            <option value={'full_name'}>name</option>
+            <option value={'created'}>created</option>
+            <option value={'updated'}>updated</option>
+            <option value={'pushed'}>pushed</option>
+          </select>&nbsp;
+          <select onChange={this.sortDirectionChange} defaultValue="asc">
+            <option value={'asc'}>asc</option>
+            <option value={'desc'}>desc</option>
+          </select>
+        </div> */}
+        <h2 style={{ margin: 0, padding: 0 }}>Projects</h2>
+        {
+          projects && !projects.length ? <p className="well">
+            You have no projects configured. Please add a GitHub project below, or upload a project using the &quot;Upload Project&quot; button.
+          </p> : null
+        }
+        <Table celled striped className={'data-table'}>
+          <Table.Body>
+            { RepoRows }
+            { ProjectsRows }
+          </Table.Body>
+        </Table>
+      </div>
+    }
+    else return null
+  }
+
+  sortOptionChange = e => {
+    const sortReposBy = e.target.value
+    if (sortReposBy != this.state.sortReposBy) this.setState({
+      sortReposBy,
+      repos: null,
+    })
+  }
+
+  sortDirectionChange = e => {
+    const sortReposDirection = e.target.value
+    if (sortReposDirection != this.state.sortReposDirection) this.setState({
+      sortReposDirection,
+      repos: null,
+    })
+  }
+
+  getBranches = async currentRepo => {
+    const { default_branch: defaultBranch, full_name: fullName } = currentRepo
+    console.log(currentRepo)
+    window.scrollTo({ top: 0 })
+    this.setState({ working: true })
+    const [ owner, repo ] = fullName.split('/')
+    let branches = await githubApi.getBranches(owner, repo)
+    branches = branches.map(b => b.name)
+    this.setState({ branches, currentRepo: fullName })
+    this.getTree(defaultBranch)
+  }
+
+  getTree = async branchName => {
+    window.scrollTo({ top: 0 })
+    this.setState({ working: true })
+    const [ owner, repo ] = this.state.currentRepo.split('/')
+    const data = await this._getTree(
+      owner,
+      repo,
+      branchName,
+    )
+    this.setState({ ...data, working: false })
+  }
+
+  RepoContents = () => {
+    const { branches, branchName, currentRepo, showFiles, tree } = this.state
+    if (tree) {
+      let newProjectPath = `${this.state.currentRepo}/tree/${this.state.branchName}`
+      newProjectPath = '/project/' + newProjectPath.replace(/\//g,'%2F')
+      newProjectPath += '?gh=' + tree.sha
+      this.setState({
+        redirect: newProjectPath
+      })
+      return null
+      // const contents = tree.tree && tree.tree.length ? tree.tree.map((t, k) => 
+      // <Table.Row key={k}>
+      //   <Table.Cell>
+      //     { t.path }
+      //   </Table.Cell>
+      // </Table.Row>) : <Table.Row key={0}>
+      //   <Table.Cell>Not found.</Table.Cell>
+      // </Table.Row>
+      // return <div className="repo-list">
+      //   <h3 style={{ padding: 0 }}>GitHub Repo: <code>{currentRepo}</code></h3>
+      //   <h3 style={{ padding: 0, margin: 0 }}>Branch: <select ref={r => this.selectedBranch = r}
+      //     onChange={() => {
+      //       this.setState({branchName: this.selectedBranch.value})
+      //   }}>{
+      //     branches.map(b => {
+      //       return <option selected={b === branchName}>{b}</option>
+      //     })
+      //   }</select></h3>
+      //   <p style={{ marginTop: 15 }}>GitHub Tree SHA: <code>{tree.sha}</code></p>
+      //   <p>
+      //     {tree.tree.filter(t => t.type === 'blob').length} total files &nbsp;
+      //     <a onClick={() => { this.setState({ showFiles: !showFiles })}}>
+      //       show / hide
+      //     </a>
+      //   </p>
+      //   <Table celled striped className={'data-table'}
+      //     style={{ display: !showFiles ? 'none' : 'table' }}>
+      //     <Table.Body>
+      //       { contents }
+      //     </Table.Body>
+      //   </Table>
+      //   <StlButton semantic onClick={() => { this.setState({branches: null, tree: null}) }}>&laquo; back</StlButton>
+      //   &nbsp;
+      //   <Link to={newProjectPath}>
+      //     <StlButton semantic primary onClick={this.testRepo}>Test This GitHub Repo &raquo;</StlButton>
+      //   </Link>
+      // </div>
+    }
+    else return null
+  }
+
+  fetchCustomRepo = async () => {
+    this.setState({ fetchCustomRepoError: null })
+    const badPatternError = new Error('The :owner/:repo pattern is not valid.')
+    const currentRepo = document.getElementById("custom_repo").value
+    const throwError = err => {
+      err = err || new Error(`There was an error fetching branches for \`${currentRepo}\``)
+      console.error(err)
+      this.setState({
+        fetchCustomRepoError: err.message
+      })
+    }
+    if (!currentRepo) return throwError(new Error('No :owner/:repo pattern was entered.'))
+
+    if ((currentRepo.match(/\//g) || []).length !== 1) return throwError(badPatternError)
+    const [ owner, repo ] = currentRepo.split('/')
+    if (!owner || !repo) return throwError(badPatternError)
+    
+    let branches = await githubApi.getBranches(owner, repo).catch(e => { return throwError(e) })
+    if (!branches) return throwError(new Error(`No branches were found for \`${currentRepo}\``))
+    
+    branches = branches.map(b => b.name)
+    this.setState({
+      branches,
+      currentRepo,
+      working: false
+    })
+  }
+
+  LoadingRepos = () => {
+    return this.state.token && !this.state.repos && !this.state.working ?
+      <Loader active inline='centered' size='large' /> : <this.RepoList />
+  }
+
+  render() {
+    const {
+      addingProjects,
+      addNewProject,
+      branches,
+      code,
+      projects,
+      redirect,
+      repos,
+      token,
+      user,
+      working,
+    } = this.state
+    // console.log(this.state)
+    // const onSuccess = response => {
+    //   const { code } = response
+    //   this.setState({ code, working: false })
+    // }
+    // const onFailure = response => console.error(response)
+
+    if (redirect) return <Redirect to={redirect} />
+    else if (working) return <FtlLoader show={true} text={'working'} />
+    else if (!code && !token) return <FtlLoader show={true} />
+    else if (addNewProject) return <Redirect to={`/code/${addNewProject}`} />
+    else return <div id="github">
+      <Menu />
+      <FtlLoader show={working} text="working" />
+      <div className="ftl-section" style={{
+        // maxWidth: 720,
+        margin: 'auto',
+        marginTop: 18,
+        paddingRight: 30,
+      }}>
+        <StlButton style={{
+            clear: 'both',
+            float: 'right',
+            // marginRight: 30,
+            marginBottom: 12,
+            display: addingProjects || branches ? 'none' : 'inline-block'
+          }}
+          semantic
+          primary
+          className="small"
+          onClick={() => {
+            this.setState({ addingProjects: true })
+          }}>
+          <Icon name="add" />
+          Add Project
+        </StlButton>
+        <StlButton style={{
+            clear: 'both',
+            float: 'right',
+            // marginRight: 30,
+            marginBottom: 12,
+            display: addingProjects && projects && projects.length && !branches ? 'inline-block' : 'none'
+          }}
+          semantic
+          className="small"
+          onClick={() => {
+            this.setState({ addingProjects: false })
+          }}>
+          Done
+        </StlButton>
+        <StlButton style={{
+            float: 'right',
+            marginRight: 6,
+            marginBottom: 12,
+            display: addingProjects && !branches ? 'inline-block' : 'none'
+          }}
+          semantic
+          primary
+          className="small"
+          onClick={() => {
+            let projectName = prompt('Please create a name for your project.')
+            // projectName = cleanProjectName(projectName)
+            if (projectName && projectName.length) this.setState({
+              addNewProject: encodeURIComponent(
+                projectName.trim().replace(/\s\s+/g, ' ')
+              )
+            })
+          }}>
+          Upload Project
+        </StlButton>
+        <div className="white-block" style={{ clear: 'both', textAlign: 'center', padding: 18 }}>
+          <div className="block-content">
+
+            {/* {
+              !code && !token ? null :
+                <Link to={'/github'}
+                  onClick={this.resetState}
+                  style={{float: 'left'}}>&laquo; start over</Link>
+            } */}
+
+            {/* <h2>Test Your GitHub Repos</h2>
+
+            <p className="oauth-images">
+              <img src={bugcatcherShield} alt="BugCatcher" />
+              <div className="center-check">
+                <div className="icon-box">
+                  <Icon name="chevron circle right" size="big" style={{ color: 'green' }} />
+                </div>
+              </div>
+              <img src={githubLogo} alt="GitHub" />
+            </p> */}
+
+            {
+              code || token ? <this.ApiFunctions /> : null
+            }
+            {/* <React.Fragment>
+                <p>
+                  <a href={`https://github.com/login/oauth/authorize?client_id=${github.clientId}&type=user_agent&scope=user%3Aemail%2Crepo&redirect_uri=${appUrl}/github/gh_auth`}>
+                    <StlButton className="big"
+                    onClick={
+                      () => { this.setState({ working: true }) }
+                    }>Browse GitHub Repos</StlButton>
+                  </a>
+                </p>
+
+              </React.Fragment> */}
+
+            <this.LoadingRepos />
+
+            {/* <this.BranchList /> */}
+
+            <this.RepoContents />
+
+          </div>
+        </div>
+
+        <br />
+      </div>
+    </div>
+  }
+}

--- a/src/views/GitHubOAuth.js
+++ b/src/views/GitHubOAuth.js
@@ -6,7 +6,8 @@ import Loader from '../components/Loader'
 
 // helpers
 import api from '../helpers/api'
-import { appUrl } from '../config'
+import { appUrl, github } from '../config'
+import { setCookie } from '../helpers/cookies'
 
 var isFetchingToken
 
@@ -30,16 +31,18 @@ class GitHubOAuth extends Component {
 
   /** @dev Network Data ******************************/
   fetchSidFromGithubCode = async code => {
-    let sid
     try {
-      sid = await api.getSidFromGithubToken({
+      const { data } = await api.getSidFromGithubToken({
         code,
         redirectUri: `${appUrl}/github/oauth`,
         state: 'login'
       })
-    } catch(e) { console.error(e) }
-    if (sid) return sid['data']
-    else return
+      if (data) {
+        setCookie(github.tokenCookieName, data['github_token'])
+        return data
+      }
+      else return
+    } catch(e) { console.error(e); return }
   }
 
 

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -1,13 +1,14 @@
 import React, { Component } from 'react'
 
 // components
-import Dashboard from './Dashboard'
+// import Dashboard from './Dashboard'
+import Repositories from './GitHub/Repositories'
 import Landing from './Landing'
 
 export default class Home extends Component {
   render() {
     const { user } = this.props
-    if (user) return <Dashboard {...this.props} />
+    if (user) return <Repositories {...this.props} />
     else return <Landing {...this.props} />
   }
 }

--- a/src/views/Landing.js
+++ b/src/views/Landing.js
@@ -110,7 +110,7 @@ export default class Landing extends Component {
                     actionName={'User Signup'}
                     style={{ marginLeft: 15 }}
                     setUser={setUser} /> */}
-                  <a href={`https://github.com/login/oauth/authorize?client_id=${config.github.clientId}&type=user_agent&scope=user:email&redirect_uri=${config.appUrl}/github/oauth`}>
+                  <a href={`https://github.com/login/oauth/authorize?client_id=${config.github.clientId}&type=user_agent&scope=user%3Aemail%2Crepo&redirect_uri=${config.appUrl}/github/oauth`}>
                     <FtlButton className="github-button">
                       Log In with&nbsp;&nbsp;
                       <img src={githubLogo} alt="GitHub Logo" />

--- a/src/views/Project.js
+++ b/src/views/Project.js
@@ -1,128 +1,1347 @@
 /**
- * @title ProjectList
- * @req List all projects belonging to the user
+ * @title Code
+ * @req Allow user to manage Code and run Tests for a Project
  * 
- * @dev API Requests
- * @call 1 : `GET` `/project`
- * @call 2 : `DELETE` `/project` (optional)
+ * @dev UI Steps
+ * @step 1 : Show dropzone and file upload button
+ * @step 2 : Determine which files need to be uploaded
+ * @step 3 : Show "upload" button
+ * @step 4 : Uploading files
+ * @step 5 : Files uploaded, Show "test" button
+ * @step 6 : Setting up project
+ * @step 7 : Running tests
+ * @step 8 : Results ready
+ * @step -1 : Error
+ * 
+ * @dev API sequence
+ * @call 1 : `POST` `code` to `/project/<project_name>`
+ * @call 2 : `POST` to `/test_project/<project_name>` (returns a `stlid`)
+ * @call 3 : `GET` from `/run_tests/<stlid>` (returns % complete & status)
+ * @call 4 : `GET` from `/test_result/<stlid>` (when status="COMPUTING_PDF" or status="COMPLETE")
  */
 
 import React, { Component } from 'react'
 import { Link, Redirect } from 'react-router-dom'
+import { Header, Icon, Progress, Tab, Table, Segment, Select } from 'semantic-ui-react'
+import { sha256 } from 'js-sha256'
+import moment from 'moment'
+import queryString from 'query-string'
 
 // components
-import ProjectsHelpModal from '../components/ProjectsHelpModal'
+// import CodeListNav from '../components/CodeListNav'
+// import ProjectHelpModal from '../components/ProjectHelpModal'
+import Loader from '../components/Loader'
 import Menu from '../components/Menu'
-import ProjectList from '../components/ProjectList'
-import ThemeLogo from '../components/ThemeLogo'
+import { durationBreakdown } from '../helpers/moment'
+import FileList from '../components/FileList'
 import StlButton from '../components/StlButton'
+// import ThemeLogo from '../components/ThemeLogo'
+import ResultsRow from '../components/ResultsRow'
 
 // context
 import { UserContext } from '../contexts/UserContext'
 
 // helpers
 import api from '../helpers/api'
+import {
+  appendS,
+  cleanProjectName,
+  destructureProjectName,
+  uriEncodeProjectName,
+  uriDecodeProjectName,
+  noLeadingSlash,
+} from '../helpers/strings'
+import { buildResultsMatrix, groupedResultsJson } from '../helpers/data'
+import { getCookie } from '../helpers/cookies'
 import config from '../config'
-import { cleanProjectName } from '../helpers/strings'
+import LocalStorage from '../helpers/LocalStorage'
+import { scrollTo } from '../helpers/scrollTo'
+import githubApi from '../helpers/githubApi'
 
 // images & styles
-import githubText from '../assets/images/github-inverted.png'
-import githubLogo from '../assets/images/github-logo-inverted.png'
+import githubText from '../assets/images/github.png'
+import githubLogo from '../assets/images/github-logo.png'
+import '../assets/css/Project.css'
+import '../assets/css/Results.css'
+
+// constants and global variables
+const initialState = {
+  binaryFilesToUpload: [],
+  codeOnServer: null,
+  files: [],
+  filesToUpload: [],
+  showResults: true,
+  statusRows: [],
+  step: 1,
+  uploadButtonClassname: 'hide',
+  uploadErrors: [],
+}
+const constStatus = {
+    'COMPLETE': 'COMPLETE',
+    'COMPUTING_PDF': 'COMPUTING_PDF',
+    'RUNNING': 'RUNNING',
+    'SETUP': 'SETUP'
+  },
+  maxConcurrentUploads = 99,
+  uploadsPerSecond = 0, // 0 = unlimited
+  millisecondTimeout = Math.floor(1000 / uploadsPerSecond),
+  uiUploadThreshold = 1000,
+  retryAttemptsAllowed = 300,
+  retryIntervalMilliseconds = 9000,
+  strStatus = {
+    [constStatus.COMPUTING_PDF]: 'Test Complete!',
+    [constStatus.RUNNING]: 'Running Tests...',
+    [constStatus.SETUP]: 'Setting up Tests...',
+  },
+  tokenCookieName = config.github.tokenCookieName
+const tabTitles = [
+  'Overview',
+  'Issues',
+  'Files',
+  'Settings',
+]
+
+let retryAttempts = 0,
+  lastPercentComplete = 0,
+  projectName,
+  currentUploadQueue,
+  statusCheck,
+  startCounting,
+  testTimeElapsed = 0,
+  successfulUploads = 0,
+  concurrentUploads = 0,
+  ghTreeSha
 
 export default class Project extends Component {
-  state = {}
-
   static contextType = UserContext
 
-  componentWillMount() {
-    this.fetchProjects()
+  constructor() {
+    super()
+    this.state = {
+      ...initialState,
+      dirName: null,
+      removeDirName: false,
+    }
+    this._countUp = this._countUp.bind(this)
+    this._restoreDirName = this._restoreDirName.bind(this)
+    this._runTests = this._runTests.bind(this)
+    this._getTree = githubApi.getTree.bind(this)
   }
 
-  fetchProjects = async () => {
-    if (this.props.user) {
-      const { data = {} } = await api.getProject().catch(() => ({}))
-      let { response: projectsOnServer = [] } = data
-      projectsOnServer = projectsOnServer.map(p => ({
-        name: p,
-        icon: 'code',
-      }))
-      this.setState({ projectsOnServer })
+  /** @dev Lifecycle methods */
+  async componentWillMount() {
+    projectName = this.props.match ? decodeURIComponent(this.props.match.params.id) : null
+
+    const selectedBranch = projectName.split('/tree/')[1]
+    console.log({projectName,selectedBranch})
+    let branchesOptions
+    if (selectedBranch) {
+      const token = getCookie(tokenCookieName)
+      if (!token) this.context.actions.logOut()
+      else {
+        githubApi.setToken(token)
+        const branches = await githubApi.getBranches(
+          projectName.split('/')[0],
+          projectName.split('/')[1]
+        )
+        branchesOptions = branches.map(b => {
+          let newProjectPath = `${projectName.split('/')[0]}/${projectName.split('/')[1]}/tree/${b.name}`
+          newProjectPath = '/project/' + newProjectPath.replace(/\//g,'%2F')
+      
+          return {
+            key: b.commit.sha,
+            onClick: () => {
+              window.location.href = newProjectPath
+            },
+            text: b.name,
+            value: b.name,
+          }
+        })
+      }
+    }
+    this.setState({
+      branchesOptions,
+      projectName,
+      selectedBranch,
+    })
+
+
+    // let lastProjectsAccessed = JSON.parse(getCookie("lastProjectsAccessed") || '[]')
+    // lastProjectsAccessed = lastProjectsAccessed.filter(p => p !== cleanProjectName(projectName))
+    // let newList = [ cleanProjectName(projectName) ]
+    // for (let i = 0; i < 5; i++) {
+    //   if (lastProjectsAccessed[i]) newList.push( lastProjectsAccessed[i] )
+    // }
+    // setCookie("lastProjectsAccessed", JSON.stringify(newList))
+
+    const fetchedUser = await this.context.actions.fetchUser()
+    if (fetchedUser && api.getStlSid()) this._fetchProductCode()
+    else setTimeout(this._fetchProductCode, 1000)
+
+    let testResultSid = LocalStorage.ProjectTestResults.getIds(projectName)
+    testResultSid = testResultSid[0]
+
+    this.fetchLastTest( testResultSid )
+    this._fetchGithubRepo()
+
+    const startTest = queryString.parse(document.location.search)['start_test']
+    if (startTest) {
+      this._runTests()
+      if (window.history.pushState) {
+        const newurl = `${window.location.protocol}//${window.location.host}${window.location.pathname}`
+        window.history.pushState({path: newurl}, '', newurl)
+      }
+    }
+
+    if (!this.state.results && this.state.testResultSid) this.fetchResults(
+      this.state.testResultSid
+    )
+
+    this._updateTabFromHash()
+
+  }
+
+  componentWillUnmount() {
+    clearTimeout( statusCheck )
+    clearInterval( startCounting )
+    statusCheck = null
+    startCounting = null
+    testTimeElapsed = 0
+    currentUploadQueue = null
+  }
+
+  _updateTabFromHash() {
+    let { hash } = window.location
+    if (hash) {
+      hash = hash.substring(1)
+      let newTabIndex
+      tabTitles.forEach((title, i) => {
+        if (title === hash) newTabIndex = i
+      })
+      this.setState({
+        activeTabIndex: newTabIndex
+      })
+    }
+  }
+  
+  
+  async fetchResults(stlid) {
+    const { data: results } = await api.getTestResult({ stlid })
+    this.setState({ results })
+  }
+
+  async fetchLastTest(testResultSid) {
+    this.setState({ fetchingLastTest: true, testResultSid })
+
+    const getLastTest = async (stlid) => {
+      if (!stlid) return null
+      const getRunTests = await api.getRunTests({ stlid }).catch(() => null)
+      const { data } = getRunTests || {}
+      const { response } = data || {}
+      return response
+    }
+
+    let results = testResultSid ? await getLastTest( testResultSid ) : null
+
+    // if (results && (results.status_msg === 'COMPUTING_PDF' || results.status_msg === 'COMPLETE')) results.percent_complete = 100
+        
+    if (!results) {
+      console.log('no results')
+      results = testResultSid = null
+      this.setState({
+        results,
+        testResultSid,
+      })
+      LocalStorage.ProjectTestResults.setIds(projectName)
+    }
+    else if (!results.test_run_result && results.status_msg !== 'COMPUTING_PDF' && results.status_msg !== 'COMPLETE') {
+      // resume GET /run_tests
+      startCounting = setInterval(this._countUp, 1000)
+      this._initCheckTestStatus(testResultSid)
+    }
+    // else this.setState({ fetchingLastTest: false, results })
+  }
+
+  /** @dev Component methods */
+  _fetchProductCode = async () => {
+    const { data = {} } = await api.getProject(uriEncodeProjectName(projectName)).catch(() => ({}))
+    const { response: projectOnServer = {} } = data
+    const { code: codeOnServer = [] } = projectOnServer
+    this.setState({
+      codeOnServer: codeOnServer.map(c => ({
+        ...c,
+        status: 'code'
+      })),
+    })
+  }
+
+  _restoreDirName = name => !this.state.removeDirName ? name : noLeadingSlash(this.state.dirName + '/' + name)
+
+  _resetUploadButton = () => {
+    clearTimeout( statusCheck )
+    clearInterval( startCounting )
+    statusCheck = null
+    startCounting = null
+    this.setState({
+      ...initialState,
+    })
+    currentUploadQueue = null
+    retryAttempts = 0
+    lastPercentComplete = 0
+    this._fetchProductCode()
+  }
+  
+  _uploadFiles = async () => {
+    console.log(`begin uploading files: ${uriDecodeProjectName(projectName)}`)
+    const thisUploadQueue = currentUploadQueue = new Date().getTime()
+    let {
+      codeOnServer = [],
+      binaryFilesToUpload = [],
+      filesToUpload,
+      numFilesDropped = 0,
+      showCodeList,
+    } = this.state
+    showCodeList = showCodeList && numFilesDropped <= uiUploadThreshold
+    this.setState({
+      step: 4,
+      codeOnServer: codeOnServer.map(c => {
+        return c.status !== 'sync' ? c :
+          ({
+            ...c,
+            status: 'code'
+          })
+      }),
+      showCodeList,
+    })
+
+    // clear then show status messages
+    let errorCount = 0,
+      uploaded = [],
+      toUpload = [...binaryFilesToUpload],
+      interval
+    const checkUploadsComplete = () => {
+      if (uploaded.length + errorCount === binaryFilesToUpload.length) { 
+        clearInterval(interval)
+        if (errorCount === 0) this.setState({ step: 5, showCodeList: false })
+        else this.setState({ step: -1 })
+        // window.mixpanel.track('Files Uploaded', {
+        //   project,
+        //   fileCount: binaryFilesToUpload.length,
+        //   version,
+        // })
+      }
+    }
+    const apiError = (err, file) => {
+      console.error(err)
+      errorCount++
+      this._updateCodeRowStatus(file, 'failed')
+      checkUploadsComplete()
+    }
+    const sendFile = (file) => {
+      concurrentUploads++
+
+      // upload file
+      const filePath = noLeadingSlash(file.path)
+      let thisCodeOnClient = filesToUpload.find(f => this._restoreDirName(f.name) === filePath)
+      thisCodeOnClient.status = 'upload'
+      const thisCodeOnServer = this.state.codeOnServer ? this.state.codeOnServer
+        .filter(c => this._restoreDirName(c.name) !== filePath)
+        .concat(thisCodeOnClient) :
+          null
+      this.setState({
+        codeOnServer: thisCodeOnServer,
+      })
+      const code = file.code
+      api.putCode({
+        name: thisCodeOnClient.name,
+        code,
+        project: cleanProjectName(projectName)
+      })
+      .then(apiResponse => {
+        successfulUploads++
+        concurrentUploads--
+        if (!apiResponse) apiError(null, file)
+        else {
+          this._updateCodeRowStatus(file, 'code')
+          uploaded.push(file)
+          checkUploadsComplete()
+        }
+      })
+      .catch(err => apiError(err, file))
+    }
+
+    // send the files
+    const sendFiles = () => {
+      if (
+        currentUploadQueue === thisUploadQueue
+        && concurrentUploads <= maxConcurrentUploads
+      ) {
+        if (!toUpload.length) checkUploadsComplete()
+        else {
+          const file = toUpload[0]
+          toUpload = toUpload.filter(f => f !== file)
+          // console.log(`upload ${file.name} after pausing ${millisecondTimeout} milliseconds with ${concurrentUploads} files in queue and ${successfulUploads} successful uploads`)
+          sendFile(file)
+        }
+      }
+    }
+    if (
+      toUpload.length > maxConcurrentUploads ||
+      (millisecondTimeout & millisecondTimeout !== Infinity)
+    ) interval = setInterval(
+      sendFiles,
+      millisecondTimeout
+    )
+    else if (toUpload.length) {
+      toUpload.forEach(f => sendFile(f))
+    }
+    else this.setState({ step: 5, showCodeList: false })
+
+  }
+
+  _runTests = async (fetchFiles) => {
+    console.log(`begin testing repo: ${projectName}`)
+    if (fetchFiles) {
+      const [ owner, repo, branch ] = destructureProjectName(projectName)
+      const { tree } = await githubApi.getTree(
+        ...destructureProjectName(projectName)
+      )
+      if (!tree) return
+      
+      const { sha } = tree
+      let newProjectPath = `${owner}/${repo}/tree/${branch}`
+      newProjectPath = '/project/' + newProjectPath.replace(/\//g,'%2F')
+      if (sha) newProjectPath += '?gh=' + sha
+
+      window.location.href = newProjectPath
+    }
+    else {
+      clearTimeout( statusCheck )
+      clearInterval( startCounting )
+      statusCheck = null
+      startCounting = setInterval(this._countUp, 1000)
+      testTimeElapsed = 0
+      successfulUploads = 0
+      this.setState({
+        activeTabIndex: 0,
+        step: 6,
+        filesToUpload: [],
+        binaryFilesToUpload: [],
+        results: null,
+        testResultSid: null,
+        ghTree: {},
+        branchName: null,
+        repo: null,
+        owner: null,
+        uploadErrors: [],
+      })
+      await this._fetchProductCode()
+
+      // scrollTo('bottom', true)
+
+      // tell the server to run tests
+      const runTestsError = (err) => {
+        err = err || new Error('POST /run_tests returned a bad response')
+        alert(err.message)
+        this.setState({
+          step: -1,
+          statusRows: []
+        })
+        console.error(err)
+        return null
+      }
+      const runTests = await api.postTestProject({
+        projectName: uriEncodeProjectName(projectName)
+      }).catch(runTestsError)
+      if (runTests) {
+        const { stlid } = runTests.data
+        // window.mixpanel.track('Test Run',
+        //   {
+        //     project: projectName,
+        //     stlid,
+        //     fileCount: this.state.codeOnServer.length,
+        //     version,
+        //     timeElapsed: testTimeElapsed,
+        //   }
+        // )
+        LocalStorage.ProjectTestResults.setIds(projectName, [stlid])
+        this._initCheckTestStatus(stlid)
+      }
     }
   }
 
+  async _initCheckTestStatus(stlid) {
+    clearTimeout( statusCheck )
+    lastPercentComplete = 0
+    if (!testTimeElapsed && this.state.results) {
+      const now = new Date()
+      const start = new Date(this.state.results.start)
+      testTimeElapsed = Math.floor((now.getTime() - start.getTime()) / 1000)
+    }
+    this.setState({
+      step: 7,
+      showResults: true,
+      statusRows: null,
+      testResultSid: stlid,
+    })
+    // scrollTo('bottom', true)
+    // check the status of the test
+    const checkStatusError = (err) => {
+      err = err || new Error('GET /run_tests returned a bad response')
+      alert(err.message)
+      this.setState({ step: 1 })
+      console.error(err)
+      return null
+    }
+    this.setState({ fetchingTest: true })
+    const results = await this._checkTestStatus(stlid).catch(checkStatusError)
+    this.setState({ fetchingTest: false })
+    if (results) {
+      if (results.status_msg === 'COMPUTING_PDF' || results.status_msg === 'COMPLETE') {
+        clearInterval( startCounting )
+        testTimeElapsed = 0
+        this.fetchResults(stlid)
+        this.setState({ step: 8 })
+      }
+      else this._initCheckTestStatus(stlid)
+    }    
+  }
+
+  _checkTestStatus(stlid) {
+    let { reconnecting } = this.state
+    if (!stlid) return
+    else return new Promise(async (resolve, reject) => {
+      const noConnection = (err) => {
+        reconnecting = true
+        this.setState({ reconnecting })
+        console.error(err || new Error('GET /run_tests connection timed out. Retrying...'))
+      }
+      const failed = (err) => {
+        alert("There was an error running the tests.")
+        this.setState({
+          step: -1,
+        })
+        console.error(err || new Error('GET /run_tests returned a 502 Bad Gateway response'))
+        reject()
+      }
+
+      this.setState({ fetchingTest: true })
+      const getRunTests = await api.getRunTests({ stlid }).catch(noConnection)
+      this.setState({ fetchingTest: false })
+      const { data } = getRunTests || {}
+      const { response } = data || {}
+
+      // Fail for any status in the 400's
+      if (getRunTests && response && response.status >= 400 && response.status <= 499) failed()
+      
+      // Retry failed connections
+      if (!getRunTests || !response) noConnection()
+      else {
+        reconnecting = false
+        this.setState({ reconnecting })
+      }
+
+      // abort if stlid does not match testResultSid
+      if (response && response.stlid !== this.state.testResultSid) {
+        console.log('mismatch', response.stlid, this.state.testResultSid)
+        clearInterval( statusCheck )
+        reject()
+      }
+
+      // setting up the tests
+      if (response && response.status_msg === 'SETUP') {
+        if (this.state.statusMessage !== 'SETUP') this.setState({
+          statusMessage: 'SETUP'
+        }) 
+      }
+      else if (this.state.statusMessage === 'SETUP') {
+        this.setState({
+          statusMessage: response.status_msg
+        })  
+      }
+
+      // update result data in `state`
+      if (
+        response && 
+        response.percent_complete &&
+        response.percent_complete >= lastPercentComplete
+      ) this.setState({
+        results: response,
+        reconnecting: false,
+      })
+
+      // `percent_complete` has progressed
+      if (
+        response && 
+        response.percent_complete &&
+        response.percent_complete > lastPercentComplete
+      ) {
+        lastPercentComplete = response.percent_complete
+        retryAttempts = 0
+        this.setState({ reconnecting: false })
+      }
+
+      // results are ready
+      if (response && (response.status_msg === 'COMPUTING_PDF' || response.status_msg === 'COMPLETE')) {
+        response.percent_complete = 100
+        this.setState({ results: response, reconnecting: false })
+        // window.mixpanel.track('Test Completed', {
+        //   project: projectName,
+        //   stlid,
+        //   fileCount: this.state.codeOnServer ? this.state.codeOnServer.length : 0,
+        //   version,
+        //   timeElapsed: testTimeElapsed,
+        // })
+        resolve(response)
+      }
+
+      // the incoming response is from the current test
+      else if (reconnecting || response.stlid === this.state.testResultSid) {
+        // we should be fetching or not
+        if (
+          !this.state.fetchingTest &&
+          (retryAttempts <= retryAttemptsAllowed || lastPercentComplete === 0)
+        ) {
+          retryAttempts++
+          console.log(`Test Status request #${retryAttempts} at ${lastPercentComplete}% complete`)
+          statusCheck = setTimeout(
+            () => { resolve(this._checkTestStatus(stlid)) },
+            retryIntervalMilliseconds
+          )
+        }
+        else reject()
+      }
+      else reject()
+    })
+  }
+
+  _countUp() {
+    const { statusMessage, step } = this.state
+    testTimeElapsed++
+    let testDuration = (testTimeElapsed % 60).toString() + ' second' + appendS(testTimeElapsed % 60)
+    if (Math.floor(testTimeElapsed / 60)) testDuration = Math.floor(testTimeElapsed / 60) + ' minute' + appendS(Math.floor(testTimeElapsed / 60)) + ', ' + testDuration
+    const button = document.getElementById('running_tests_button')
+    if (button) button.innerHTML = (
+      statusMessage === 'RUNNING' &&
+      step !== 6
+    ) ? `${strStatus[constStatus.RUNNING]} (${testDuration})` : `${strStatus[constStatus.SETUP]} (${testDuration})`
+  }
+
+  _updateCode = (row, status) => {
+    const { codeOnServer, showCodeList } = this.state
+    const newCodeOnServer = status ? codeOnServer.map(c => {
+      if (c.name !== row.name) return c
+      else return { ...c, status }
+    }) :
+    codeOnServer.filter(
+      c => c.name !== row.name
+    )
+    this.setState({
+      codeOnServer: newCodeOnServer,
+      showCodeList: newCodeOnServer.length ? showCodeList : false,
+    })
+  }
+
+  _removeFileToUpload = file => {
+    const updatedBinaryFilesToUpload = this.state.binaryFilesToUpload.filter(
+      b => b.name !== file.name
+    )
+    const updatedCodeOnServer = this.state.codeOnServer.filter(
+      b => b.name !== file.name
+    )
+    const step = updatedBinaryFilesToUpload.length ? this.state.step : 1
+    this.setState({
+      binaryFilesToUpload: updatedBinaryFilesToUpload,
+      codeOnServer: updatedCodeOnServer,
+      step,
+    })
+  }
+
+  _showCodeList = () => {
+    const showCodeList = !this.state.showCodeList
+    const showDropzone = !showCodeList && this.state.showDropzone
+    this.setState({ showCodeList, showDropzone })
+  }
+
+  _toggleDropzone = () => {
+    const showDropzone = !this.state.showDropzone
+    this.setState({ showDropzone })
+    if (showDropzone) setTimeout(() => {
+      scrollTo('dropzone', true, document.getElementById('ftl_navbar').offsetHeight) },
+      300
+    )
+  }
+
+  _updateCodeRowStatus = (file, status) => {
+    const { codeOnServer = [], filesToUpload = [] } = this.state
+    const filePath = noLeadingSlash(file.path)
+    let thisCodeOnClient = filesToUpload.find(f => this._restoreDirName(f.name) === filePath) || {}
+    thisCodeOnClient.status = status
+    this.setState({
+      codeOnServer: (codeOnServer || [])
+        .filter(c => this._restoreDirName(c.name) !== filePath)
+        .concat(thisCodeOnClient)
+    })
+  }
+
+  _setState = state => this.setState(state || initialState)
+
+  /** @title GitHub */
+  _fetchGithubRepo = async () => {
+
+    /** @dev Fetch GitHub repo if querystring param is found */
+    ghTreeSha = queryString.parse(document.location.search)['gh']
+    if (ghTreeSha) {
+      if (window.history.pushState) {
+        const newurl = `${window.location.protocol}//${window.location.host}${window.location.pathname}`
+        window.history.pushState({path: newurl}, '', newurl)
+      }
+      console.log(`begin fetching github repo: ${projectName}`)
+      const token = getCookie(tokenCookieName)
+      if (token) {
+        githubApi.setToken(token)
+        this.setState({ working: true })
+        const [ owner, repo, ref, branchName ] = projectName.split('/')
+        const { tree } = await this._getTree(
+          owner,
+          repo,
+          branchName,
+        )
+        if (tree && tree.tree) {
+          this.setState({
+            activeTabIndex: 2,
+            ghTree: tree,
+            branchName,
+            repo,
+            owner,
+            step: 4,
+            working: false,
+          })
+          this._testGithubRepo()    
+        }
+      }
+    }    
+  }
+
+  _testGithubRepo = async () => {
+    console.log(`begin uploading files: ${projectName}`)
+    const { owner, repo, ghTree } = this.state
+    const thisUploadQueue = currentUploadQueue = new Date().getTime()
+    await this._fetchProductCode()
+
+    // clear then show status messages
+    let uploadErrors = [],
+      uploaded = [],
+      toUpload = ghTree.tree.filter(t => t.type === 'blob'),
+      retryFailedUploadsAttempt = 0,
+      interval
+    const treeSize = toUpload.length
+
+    this.setState({
+      ghFileCount: treeSize,
+    })
+
+    const checkUploadsComplete = () => {
+      if (uploaded.length + uploadErrors.length === treeSize) { 
+        if (!uploadErrors.length) {
+          clearInterval(interval)
+          this._fetchProductCode()
+          // window.mixpanel.track('GitHub Files Uploaded', {
+          //   project: projectName,
+          //   fileCount: toUpload.length,
+          //   version,
+          // })
+          this._runTests()
+        }
+        else if (retryFailedUploadsAttempt < 3) {
+          retryFailedUploadsAttempt++
+          console.log('Retry attempt #' + retryFailedUploadsAttempt)
+          successfulUploads = successfulUploads - uploadErrors.length
+          toUpload = uploadErrors
+          uploadErrors = []
+        }
+        else {
+          clearInterval(interval)
+          this.setState({ step: -1, uploadErrors })
+        }
+      }
+      this.setState({
+        ghUploaded: uploaded.length,
+      })
+    }
+    const fetchBlobError = (err, file) => {
+      console.error(err)
+      console.log(`Failed: ${file.sha}`, file.path)
+      return null
+    }
+    const apiError = (err, file) => {
+      err = err || new Error(`Failed to push file: ${file.path}`)
+      console.error(err)
+      uploadErrors.push(file)
+      checkUploadsComplete()
+    }
+    const sendFile = async (file) => {
+      concurrentUploads++
+      const blob = await githubApi.getBlob(owner, repo, file.sha)
+        .catch(() => null)
+      if (!blob) { fetchBlobError(new Error('Failed to fetch blob.'), file) }
+      else {
+        // check the sha256 hash to skip any synchronized files
+        const code = 'data:application/octet-stream;base64,' + blob['content']
+        let binStringToHash = sha256(atob(blob['content']))
+        const synchronized = Boolean(this.state.codeOnServer.find(f => f.sha256 === binStringToHash))
+
+        const putCodeCallback = (apiResponse, file) => {
+          successfulUploads++
+          concurrentUploads--
+          if (!apiResponse) apiError(null, file)
+          else {
+            uploaded.push(file)
+            checkUploadsComplete()
+          }
+        }
+
+        if (synchronized) {
+          // console.log(`\tSkipping synchronized file ${file.path}`)
+          putCodeCallback(true, file)
+        }
+        else {
+          // console.log(`\tUploading file ${file.path}`)
+          api.putCode({
+            name: file.path,
+            code,
+            project: cleanProjectName(projectName),
+          })
+          .then(res => {putCodeCallback(res, file)})
+          .catch(err => apiError(err, file))
+        }
+        // api.putCode({
+        //   name: file.path,
+        //   code: 'data:application/octet-stream;base64,' + blob['content'],
+        //   project: encodeURIComponent(projectName),
+        // })
+        // .then(apiResponse => {
+        //   successfulUploads++
+        //   concurrentUploads--
+        //   if (!apiResponse) apiError(null, file)
+        //   else {
+        //     // this._updateCodeRowStatus(file, 'code')
+        //     uploaded.push(file)
+        //     checkUploadsComplete()
+        //   }
+        // })
+        // .catch(err => apiError(err, file))
+      }
+    }
+
+    // send the files
+    const sendFiles = () => {
+      if (
+        currentUploadQueue === thisUploadQueue
+        && concurrentUploads <= maxConcurrentUploads
+      ) {
+        if (!toUpload.length) checkUploadsComplete()
+        else {
+          const file = toUpload[0]
+          toUpload = toUpload.filter(f => f !== file)
+          // console.log(`upload ${file.path} after pausing ${millisecondTimeout} milliseconds with ${concurrentUploads} files in queue and ${successfulUploads} successful uploads`)
+          sendFile(file)
+        }
+      }
+    }
+    interval = setInterval(
+      sendFiles,
+      millisecondTimeout
+    )
+  }
+
+  /** @dev Sub components */
   Instructions = () => {
-    const { projectsOnServer } = this.state
+    const {
+      codeOnServer,
+      step,
+    } = this.state
 
-    if (!projectsOnServer) return <React.Fragment>
-      <p className="lead">Syncing your projects... Please wait...</p>
-    </React.Fragment>
-    else if (projectsOnServer && !projectsOnServer.length) return <React.Fragment>
-      <p className="lead">No projects found.</p>
-    </React.Fragment>
-    else return <React.Fragment>
-      <ProjectList {...this.props}
+    // fetching project Code
+    if (!codeOnServer) return <div>
+      <p className="lead">Syncing your project... Please wait...</p>
+    </div>
+
+    // show the Code List
+    else if (step !== 4) return <div className="upload-status">
+      <FileList {...this.props}
         state={this.state}
-        updateProjects={projectsOnServer => {this.setState({ projectsOnServer })}} />
-    </React.Fragment>
+        runTests={this._runTests}
+        setState={this._setState}
+        restoreDirName={this._restoreDirName}
+        toggleDropzone={this._toggleDropzone}
+        removeFileToUpload={this._removeFileToUpload}
+        showLoader={deleting => this.setState({ deletingFiles: deleting })}
+        updateCode={this._updateCode} />
+    </div>
+
+    else return null
   }
 
+  /** @dev Render component */
   render() {
-    const { user } = this.props
-    const { addNewProject } = this.state
-    const Contents = () => {
-      if (user) return <div className="upload-container">
-        <div style={{
-          fontSize: 24,
-          verticalAlign: 'middle',
-          paddingBottom: 21,
-          borderBottom: '1px solid gray'
-        }}>
-          <ProjectsHelpModal {...this.props} />
-          <Link to={`/projects`}>
-            <ThemeLogo style={{ width: 180, verticalAlign: 'middle', marginRight: 18 }} />
-          </Link>
-        </div>
-
-        <div style={{
-          marginTop: 15
-          }}>
-          <h2>Your Projects:</h2>
-          <this.Instructions
-            state={this.state}
-            {...this.props} />
-          <StlButton
-            onClick={() => {
-              let projectName = prompt('What is the name of your project?')
-              projectName = cleanProjectName(projectName)
-              if (projectName.length) this.setState({
-                addNewProject: encodeURIComponent(
-                  projectName.trim().replace(/\s\s+/g, ' ')
-                )
-              })
-            }}>Upload a New Project</StlButton>
-            &nbsp;
-            <Link to={'/github'}>
-              <StlButton className="github-button">
-                Test a&nbsp;&nbsp;
-                <img src={githubLogo} alt="GitHub Logo" />
-                <img src={githubText} alt="GitHub Text" />
-                &nbsp;Repository
-              </StlButton>
-            </Link>
-        </div>
-
-      </div>
-      else return <div>Please log in.</div>
+    let {
+      binaryFilesToUpload,
+      branchName,
+      branchesOptions,
+      codeOnServer,
+      deletingFiles,
+      droppingFiles,
+      numFilesDropped = 0,
+      numFilesToDelete,
+      owner,
+      reconnecting,
+      redirect,
+      repo,
+      results,
+      selectedBranch,
+      showGithubFiles,
+      showDropzone,
+      showResults,
+      step,
+      testResultSid,
+      ghTree = {},
+      ghTreeSha,
+      ghUploaded = 0,
+      ghFileCount = 0,
+      uploadErrors = [],
+      working,
+    } = this.state
+    const treeSize = !ghTree.tree ? null : ghTree.tree.filter(t => t.type === 'blob').length
+    const percentComplete = Math.floor((ghUploaded / ghFileCount) * 100)
+    // console.log({percentComplete, ghUploaded, ghFileCount})
+    results = results || { // inital state for the results table
+      status_msg: 'SETUP',
+      codes: [],
+      percent_complete: 0,
     }
+    const resultsMatrix = buildResultsMatrix(results)
+    showDropzone = showDropzone || (codeOnServer && codeOnServer.length === 0)
+    let testDuration = (testTimeElapsed % 60).toString() + ' second' + appendS(testTimeElapsed % 60)
+    if (Math.floor(testTimeElapsed / 60)) testDuration = Math.floor(testTimeElapsed / 60) + ' minute' + appendS(Math.floor(testTimeElapsed / 60)) + ', ' + testDuration
+    const numFailedUploads = codeOnServer && codeOnServer.length ?
+      codeOnServer.filter(c => c.status === 'failed').length : 0
+    
+    const evaluatingFilesLoaderText = <span>
+      Evaluating {numFilesDropped} Files
+      <br />&nbsp;
+      <p>
+        <StlButton default semantic
+          onClick={() => { document.location.reload() }}
+        >cancel</StlButton>
+      </p>
+    </span>
 
-    if (addNewProject) return <Redirect to={`/project/${addNewProject}`} />
+    if (droppingFiles) return <Loader text={evaluatingFilesLoaderText} />
+    else if (deletingFiles) return <Loader text={`Deleting ${numFilesToDelete} Files`} />
+    else if (redirect) return <Redirect to={redirect} />
+    else if (working) return <Loader text={`working`} />
+    else if (reconnecting) return <Loader text={`Re-establishing Network Connection...`} />
     else return <div className={`theme`}>
       <Menu />
-      <section id="upload" className="contents">
-        <h3 style={{ textAlign: 'center', margin: '36px 0' }}>Feedback or bug reports about the BugCatcher beta? Email <a href={`mailto:${config.helpEmail}`}>{config.helpEmail}</a></h3>
-          <Contents />
+      <section id="project">
+
+        <div className="ftl-section">
+
+          <h2 style={{ display: 'inline-block', margin: '18px 18px 0 18px' }}>
+            <Icon name={projectName.match('/tree/') ? 'code branch' : 'code'} />&nbsp;
+            {projectName.split('/tree/')[0]}
+          </h2>
+
+          <div style={{
+            display: results && !results.test_run_result ? 'block' : 'none',
+            margin: '18px 0',
+          }}>
+            {/** @title Code Testing  */}
+            <section>
+
+              {/* uploading */}
+              <div style={{
+                width: '100%',
+                display: !ghTree.tree && step === 4 ? 'inline-block' : 'none'
+              }}>
+                <Progress percent={Math.floor((successfulUploads / binaryFilesToUpload.length) * 100)} style={{
+                    marginTop: -6,
+                  }}
+                  color={(successfulUploads / binaryFilesToUpload.length) === 1 ? 'green' : 'yellow'}
+                  progress />
+                <StlButton className="btn working secondary full-width center-text"
+                    style={{
+                      verticalAlign: 'middle',
+                    }}>Uploading...</StlButton>
+              </div>
+
+              {/* run tests */}
+              <StlButton style={{
+                  display: ![3,4,5,6,7].includes(step) &&
+                    !testResultSid && numFailedUploads ? 
+                      'block' : 'none',
+                }}
+                className={'link red'}
+                onClick={this._showCodeList}>
+                <Icon name="warning sign" />
+                {`${numFailedUploads} file${appendS(numFailedUploads)} failed to upload`}
+              </StlButton>
+
+              {/** @title Results Status Table */}
+              {/** @todo Refactor to its own component */}
+              <Segment secondary id="last_test" style={{
+                  display: showResults && testResultSid && [5,6,7].includes(step) ? 'inline-block' : 'none',
+                  width: '100%',
+                  margin: 0,
+                }}>
+                  <span
+                    style={{
+                      display: step === 6 ? 'inline-block' : 'none',
+                      verticalAlign: 'middle',
+                    }}>Setting Up Tests...</span>
+
+                <span
+                  style={{
+                    display: step === 7 ? 'inline-block' : 'none',
+                    verticalAlign: 'middle',
+                  }}>Testing Project...</span>
+
+                {
+                  results ? <Progress percent={results.percent_complete || 0} style={{
+                    marginTop: 6,
+                  }}
+                  color={results.status_msg === 'COMPUTING_PDF' || results.status_msg === 'COMPLETE' ? 'green' : 'yellow'}
+                  progress /> : null
+                }
+              </Segment>
+
+            </section>
+          </div>
+        
+        </div>
+
+        <UserContext.Consumer>
+          {(userContext) => {
+            const { user } = userContext ? userContext.state : {}
+            if (user && (user.isSubscriber || !process.env.REACT_APP_USE_PAYWALL)) {
+
+              const { test_run: testRun, test_run_result: testResults = [] } = results
+              const fileCount = testResults.length
+              const startTest = testRun ? moment(testRun.start) : null
+              const endTest = testRun ? moment(testRun.end) : null
+              let languagesFound = new Array()
+              let toolsUsed = new Array()
+              testResults.forEach(c => {
+                languagesFound.push(c['test_suite_test']['test_suite']['language'])
+                toolsUsed.push(c['test_suite_test']['test_suite']['name'])
+              })
+              languagesFound = Array.from(new Set(languagesFound)).join(', ')
+              toolsUsed = Array.from(new Set(toolsUsed)).join(', ')
+
+              const OverviewContents = () => testResultSid || (results && results.test_run_result) ? <div className="overview">          
+                <span
+                style={{
+                  display: [6,7].includes(step) ? 'inline-block' : 'none',
+                  verticalAlign: 'middle',
+                }}>Test in progress...</span>
+                
+                {/* <Segment color="blue" style={{
+                  display: Boolean(results && results.test_run) ? 'block' : 'none'
+                }} className="overview-segment">
+                  <h3>Grade</h3>
+                  <div style={{
+                    textAlign: 'center',
+                    fontSize: '150%'
+                  }}>
+                    <div style={{
+                      marginTop: 45,
+                      color: 'white',
+                      borderRadius: 9,
+                      background: resultsMatrix.high ? 'red' :
+                        resultsMatrix.medium ? 'orange' :
+                          resultsMatrix.low ? 'blue' : 'gray'
+                    }}>
+                      {
+                        resultsMatrix.high ? 'Poor' :
+                          resultsMatrix.medium ? 'Normal' :
+                            resultsMatrix.low ? 'Good' : 'None'
+                      }
+                    </div>
+                  </div>
+                </Segment> */}
+
+                <div className="overview-segment" style={{
+                    display: Boolean(results && results.test_run) ? 'block' : 'none'
+                  }}>
+                  <h3>Testing Results Breakdown</h3>
+                  <Segment color="blue">
+
+                    <Table basic='very' celled collapsin className="issues-table">
+                      <Table.Header>
+                        <Table.Row>
+                          <Table.HeaderCell style={{borderTop: 'none'}}>Issue Severity</Table.HeaderCell>
+                          <Table.HeaderCell style={{borderTop: 'none'}}>Number of Issues</Table.HeaderCell>
+                        </Table.Row>
+                      </Table.Header>
+                      <Table.Body>
+                        <Table.Row>
+                          <Table.Cell>
+                            High Severity
+                          </Table.Cell>
+                          <Table.Cell className={resultsMatrix['high'] ? 'red' : ''}>{resultsMatrix['high']}</Table.Cell>
+                        </Table.Row>
+                        <Table.Row>
+                          <Table.Cell>
+                            Medium Severity
+                          </Table.Cell>
+                          <Table.Cell className={resultsMatrix['medium'] ? 'orange' : ''}>{resultsMatrix['medium']}</Table.Cell>
+                        </Table.Row>
+                        <Table.Row>
+                          <Table.Cell>
+                            Low Severity
+                          </Table.Cell>
+                          <Table.Cell className={resultsMatrix['low'] ? 'yellow' : ''}>{resultsMatrix['low']}</Table.Cell>
+                        </Table.Row>
+                      </Table.Body>
+                    </Table>
+                  </Segment>
+                  <a onClick={() => { this.setState({ activeTabIndex: 1 }) }}>
+                    See Issues
+                  </a>
+                  &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
+                  <Link to={`/results/${testResultSid}/?gh=${ghTreeSha}`} target="_blank">
+                    View Full Report
+                  </Link>
+                </div>
+
+                <div className="overview-segment" style={{
+                    display: Boolean(results && results.test_run) ? 'block' : 'none'
+                  }}>
+                  <h3>Testing Information</h3>
+                  <Segment color="blue">
+
+                    <Table basic='very' celled collapsin className="tests-table">
+                      <Table.Body>
+                        <Table.Row>
+                          <Table.Cell>
+                            Languages Found
+                          </Table.Cell>
+                          <Table.Cell>{languagesFound}</Table.Cell>
+                        </Table.Row>
+                        <Table.Row>
+                          <Table.Cell>
+                            Tools Used
+                          </Table.Cell>
+                          <Table.Cell>{toolsUsed}</Table.Cell>
+                        </Table.Row>
+                        <Table.Row>
+                          <Table.Cell>
+                            Files Tested
+                          </Table.Cell>
+                          <Table.Cell>{fileCount}</Table.Cell>
+                        </Table.Row>
+                        <Table.Row>
+                          <Table.Cell>
+                            Test Duration
+                          </Table.Cell>
+                          <Table.Cell>{durationBreakdown(startTest, endTest)}</Table.Cell>
+                        </Table.Row>
+                      </Table.Body>
+                    </Table>
+                  </Segment>
+                </div>
+
+                {/* <Segment color="blue" style={{
+                  display: Boolean(results && results.test_run) ? 'block' : 'none'
+                }} className="overview-segment">
+                  <h3>Files</h3>
+                  <div style={{
+                    textAlign: 'center',
+                    fontSize: '150%',
+                    paddingTop: 30,
+                  }}>
+                    {codeOnServer ? codeOnServer.length : ''} files
+                  </div>
+                </Segment> */}
+
+                <div style={{clear: 'left'}} />
+
+              </div> : <div style={{ display: step !== 6 ? 'block' : 'none'}}>
+                <h3>No results found. Initiate a test?</h3>
+                <StlButton className="small" semantic
+                  onClick={() => {this._runTests(true)}}>Initiate a Test</StlButton>
+              </div>
+
+              const Overview = () => <div>
+                {
+                  !selectedBranch ? null : <p>
+                    Branch&nbsp;
+                    <Select options={branchesOptions} defaultValue={selectedBranch}
+                      onChange={(e) => {
+                        console.log(e.target)
+                      }} />
+                  </p>
+                }
+                <OverviewContents />
+              </div>
+
+              const Files = () => <div>
+                {/** @title Upload GitHug repo */}
+                <div style={{
+                  display: treeSize &&
+                    (ghUploaded !== ghFileCount) ? 'block' : 'none',
+                  clear: 'right',
+                  paddingTop: 18,
+                  }} className="repo-list">
+                    <h3 style={{ padding: 0 }}>GitHub Repo: <code>{owner}/{repo}</code></h3>
+                    <h3 style={{ padding: 0, margin: 0 }}>Branch: <code>{branchName}</code></h3>
+                    <p style={{ marginTop: 15 }}>GitHub Tree SHA: <code>{ghTree.sha}</code></p>
+                    <p>
+                      Assessing {ghUploaded} of {treeSize} total files &nbsp;
+                      <a onClick={() => { this.setState({ showGithubFiles: !showGithubFiles })}}>
+                        show / hide
+                      </a>
+                    </p>
+                    <Table celled striped className={'data-table'}
+                      style={{ display: !showGithubFiles ? 'none' : 'table' }}>
+                      <Table.Body>
+                      { 
+                        ghTree.tree && ghTree.tree.length ? ghTree.tree.map((t, k) => 
+                          <Table.Row key={k}>
+                            <Table.Cell>
+                              { t.path }
+                            </Table.Cell>
+                          </Table.Row>) : <Table.Row key={0}>
+                            <Table.Cell>Not found.</Table.Cell>
+                          </Table.Row>
+                      }
+                      </Table.Body>
+                    </Table>
+                    {/* <StlButton onClick={this._testGithubRepo}>Run BugCatcher on this Repository</StlButton> */}
+                    <Progress percent={percentComplete} style={{
+                        marginTop: 21,
+                      }}
+                      color={(ghUploaded / ghFileCount) === 1 ? 'green' : 'blue'}
+                      progress />
+                    <div style={{ color: 'red', display: uploadErrors.length ? 'block' : 'none' }}>
+                      {uploadErrors.length} files were not uploaded
+                    </div>
+                </div>
+
+                <section style={{ marginTop: 12 }}>
+                  <this.Instructions {...this.state} {...this.props} style={{ marginTop: 30 }} />
+                </section>
+
+              </div>
+
+              const Issues = () => {
+                if (results && results.test_run_result) {
+                  const testId = ((results && results['stlid']) || testResultSid) ?
+                  testResultSid || results['stlid'] : null
+
+                  // parse out some data we want to display
+                  let { test_run: testRun, test_run_result: testRunResult } = results
+                  if (!Array.isArray(testRunResult)) testRunResult = []
+
+                  let [groupedResults, certified] = groupedResultsJson(testRunResult, projectName)
+
+                  const GroupedResults = () => {
+                    const rows = groupedResults
+                    if (!rows.length) return <h1 style={{ color: 'green' }}>Passing all tests!</h1>
+                    else return rows.map((r, i) => <ResultsRow key={i}
+                      user={user}
+                      {...r} />)
+                  }
+
+                  return <React.Fragment>
+                    <GroupedResults />
+                    <Link to={`/results/${testId}/?gh=${ghTreeSha}`} target="_blank">
+                      View Full Report
+                    </Link>
+                  </React.Fragment>
+                }
+                else return null
+              }
+
+              const panes = [
+                {
+                  menuItem: tabTitles[0],
+                  render: () => <Tab.Pane attached={false}><Overview /></Tab.Pane>,
+                },
+                {
+                  menuItem: tabTitles[1],
+                  render: () => <Tab.Pane attached={false}><Issues /></Tab.Pane>,
+                },
+                {
+                  menuItem: `${tabTitles[2]}${codeOnServer ? ' (' + codeOnServer.length + ')' : ''}`,
+                  render: () => <Tab.Pane attached={false}><Files /></Tab.Pane>,
+                },
+                {
+                  menuItem: tabTitles[3],
+                  render: () => <Tab.Pane attached={false}>
+                    <Segment>
+                      
+                      {
+                        projectName.match('/tree/') ?
+                          <p>Deleting this project will permanently delete tests for all branches of this repository.</p> :
+                            <p>Permanently delete all tests for this project and remove it from your Projects list.</p>
+                      }
+                      
+                      <p><StlButton semantic color="red" className="small"
+                      onClick={async (e) => {
+                        const msg = `Are you sure you want to delete this project`
+                        const conf = window.confirm(msg)
+                        if (conf) {
+                          e.target.disabled = true
+                          this.setState({working: true})
+                          let projectsToDelete = new Array()
+                          if (projectName.match('/tree/')) {
+                            const { data } = await api.getProject()
+                            const projects = data.response
+                            projects.forEach(p => {
+                              LocalStorage.ProjectTestResults.setIds(decodeURIComponent(p))
+                              projectsToDelete.push(
+                                api.deleteProjectPromise(uriEncodeProjectName(decodeURIComponent(p))).catch(() => null)
+                              )
+                            })
+                          }
+                          await Promise.all(projectsToDelete)
+                          this.setState({redirect: '/'})
+                        }
+                      }}>Delete Project</StlButton></p>
+                     </Segment>
+                  </Tab.Pane>,
+                },
+              ]
+          
+              const ProjectTabs = () => (
+                <Tab menu={{ secondary: true, pointing: true }}
+                  activeIndex={this.state.activeTabIndex} panes={panes}
+                  onTabChange={(evt, data) => {
+                    this.setState({ activeTabIndex: data.activeIndex })
+                    window.location.hash = data.panes[data.activeIndex]['menuItem'].split(' ')[0]
+                  }} />
+              )
+            
+              return <div className={'ftl-tabs ftl-section'}>
+                <a href={`https://github.com/${projectName}`} target="_blank">
+                  <StlButton link className="github-button">
+                    View on&nbsp;&nbsp;
+                    <img src={githubLogo} alt="GitHub Logo" />
+                    <img src={githubText} alt="GitHub Text" />&nbsp;
+                    <Icon name="external alternate" />
+                  </StlButton>
+                </a>
+                <ProjectTabs />
+              </div>   
+
+            }
+            else return <Redirect to={'/'} />
+          }}
+        </UserContext.Consumer>
       </section>
+      <a id="bottom" />
     </div>
   }
 }
-

--- a/src/views/Projects.js
+++ b/src/views/Projects.js
@@ -1,0 +1,117 @@
+/**
+ * @title ProjectList
+ * @req List all projects belonging to the user
+ * 
+ * @dev API Requests
+ * @call 1 : `GET` `/project`
+ * @call 2 : `DELETE` `/project` (optional)
+ */
+
+import React, { Component } from 'react'
+import { Link, Redirect } from 'react-router-dom'
+
+// components
+import ProjectsHelpModal from '../components/ProjectsHelpModal'
+import Menu from '../components/Menu'
+import ProjectList from '../components/ProjectList'
+import ThemeLogo from '../components/ThemeLogo'
+import StlButton from '../components/StlButton'
+
+// context
+import { UserContext } from '../contexts/UserContext'
+
+// helpers
+import api from '../helpers/api'
+import config from '../config'
+import { cleanProjectName } from '../helpers/strings'
+
+// images & styles
+import githubText from '../assets/images/github-inverted.png'
+import githubLogo from '../assets/images/github-logo-inverted.png'
+
+export default class Projects extends Component {
+  state = {}
+
+  static contextType = UserContext
+
+  componentWillMount() {
+    this.fetchProjects()
+  }
+
+  fetchProjects = async () => {
+    if (this.props.user) {
+      const { data = {} } = await api.getProject().catch(() => ({}))
+      let { response: projectsOnServer = [] } = data
+      projectsOnServer = projectsOnServer.map(p => ({
+        name: p,
+        icon: 'code',
+      }))
+      this.setState({ projectsOnServer })
+    }
+  }
+
+  Instructions = () => {
+    const { projectsOnServer } = this.state
+
+    if (!projectsOnServer) return <React.Fragment>
+      <p className="lead">Syncing your projects... Please wait...</p>
+    </React.Fragment>
+    else if (projectsOnServer && !projectsOnServer.length) return <React.Fragment>
+      <p className="lead">No projects found.</p>
+    </React.Fragment>
+    else return <React.Fragment>
+      <ProjectList {...this.props}
+        state={this.state}
+        updateProjects={projectsOnServer => {this.setState({ projectsOnServer })}} />
+    </React.Fragment>
+  }
+
+  render() {
+    const { user } = this.props
+    const { addNewProject } = this.state
+    const Contents = () => {
+      if (user) return <div className="white-block upload-container" style={{ borderRadius: 12, padding: '0 18px 18px 18px' }}>
+        <div style={{
+          // marginTop: 15
+          }}>
+          <ProjectsHelpModal {...this.props} />
+          <h2>Your Projects:</h2>
+          <this.Instructions
+            state={this.state}
+            {...this.props} />
+          <StlButton
+            onClick={() => {
+              let projectName = prompt('What is the name of your project?')
+              // projectName = cleanProjectName(projectName)
+              if (projectName.length) this.setState({
+                addNewProject: encodeURIComponent(
+                  projectName.trim().replace(/\s\s+/g, ' ')
+                )
+              })
+            }}>Upload a New Project</StlButton>
+            &nbsp;
+            <Link to={'/github/repos'}>
+              <StlButton className="github-button">
+                Test a&nbsp;&nbsp;
+                <img src={githubLogo} alt="GitHub Logo" />
+                <img src={githubText} alt="GitHub Text" />
+                &nbsp;Repository
+              </StlButton>
+            </Link>
+        </div>
+
+      </div>
+      else return <div>Please log in.</div>
+    }
+
+    if (addNewProject) return <Redirect to={`/code/${addNewProject}`} />
+    else return <div className={`theme`}>
+      <Menu />
+      <section id="upload" className="contents">
+            <h3 style={{ textAlign: 'center', margin: '36px 0' }}>Feedback or bug reports about the BugCatcher beta? Email <a href={`mailto:${config.helpEmail}`}>{config.helpEmail}</a></h3>
+          <Contents />
+      </section>
+    </div>
+  }
+}
+

--- a/src/views/X_Code.js
+++ b/src/views/X_Code.js
@@ -52,7 +52,7 @@ import { scrollTo } from '../helpers/scrollTo'
 import githubApi from '../helpers/githubApi'
 
 // images and styles
-import '../assets/css/components/Code.css'
+import '../assets/css/UploadFiles.css'
 import '../assets/css/Results.css'
 
 // constants and global variables
@@ -978,16 +978,17 @@ export default class Code extends Component {
 
     if (droppingFiles) return <Loader text={evaluatingFilesLoaderText} />
     else if (deletingFiles) return <Loader text={`Deleting ${numFilesToDelete} Files`} />
-    else if (redirect) return <Redirect to={redirect} />
+    else if (redirect) return <Redirect to={`/github`} />
     else if (working) return <Loader text={`working`} />
     else if (reconnecting) return <Loader text={`Re-establishing Network Connection...`} />
     else return <div className={`theme`}>
       <Menu />
-      <section id="code" className="contents">
+      <section id="upload" className="contents">
+        <h3 style={{ textAlign: 'center', margin: '36px 0' }}>Feedback or bug reports about the BugCatcher beta? Email <a href={`mailto:${config.helpEmail}`}>{config.helpEmail}</a></h3>
         <UserContext.Consumer>
           {(userContext) => {
             const { user } = userContext ? userContext.state : {}
-            if (user && (user.isSubscriber || !process.env.REACT_APP_USE_PAYWALL)) return <div className="project-container">
+            if (user && (user.isSubscriber || !process.env.REACT_APP_USE_PAYWALL)) return <div className="upload-container">
 
               <div style={{
                 fontSize: 24,
@@ -1144,9 +1145,7 @@ export default class Code extends Component {
                         'block' : 'none',
                   }}
                   className={'full-width'}
-                  onClick={() => { this.setState({
-                    redirect: `/project/${uriEncodeProjectName(projectName)}?start_test=1`
-                  }) }}>Run Tests</StlButton>
+                  onClick={this._runTests}>Run Tests</StlButton>
 
                 {/* setup */}
                 <StlButton className="btn working secondary full-width center-text"


### PR DESCRIPTION
We are changing the web client to focus on GitHub testing by landing the users on the GitHub testing view. Users can still upload code for testing but it is not the prominent action anymore. The dashboard is still accessible but not used as the landing view.